### PR TITLE
fix: update publish workflow org token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,4 +24,4 @@ jobs:
         run: |
           npm publish --access=public --non-interactive
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}


### PR DESCRIPTION
- Yuri added a token `NPM_ORG_TOKEN` to use when publishing to npm
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR