### PR TITLE
fix: create cloned html element for multiple marker results

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1205,7 +1205,11 @@ MaplibreGeocoder.prototype = {
 
     results.forEach(
       function (result) {
-        var marker = new this._maplibregl.Marker(markerOptions);
+        var el = this.options.showResultMarkers.element.cloneNode(true);
+
+        var marker = new this._maplibregl.Marker(
+          extend({}, markerOptions, { element: el })
+        );
 
         var popup;
         if (this.options.popup) {


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- When passing in a customer html element and rendering that to multiple markers only one marker would show up because they would all try to use the same DOM element
  - Fixed so that the HTML element is cloned for each marker

 - [x] briefly describe the changes in this PR
