### PR TITLE
Add debounce option for fetching search results

### DIFF
--- a/API.md
+++ b/API.md
@@ -103,6 +103,7 @@ A geocoder component that works with maplibre
     -   `options.getItemValue` **[Function][65]?** A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON][66] object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
     -   `options.localGeocoderOnly` **[Boolean][59]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher. (optional, default `false`)
     -   `options.showResultsWhileTyping` **[Boolean][59]** If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option. (optional, default `false`)
+    -   `options.debounceSearch` **[Number][58]** Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query. (optional, default `200`)
 
 ### Examples
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## master
 
+## 1.1.1
+
+### Features / Improvements 🚀
+
+- Add optional debounceSearch parameter to decide how long to wait before sending Geocoder input box query to server
+
+### Bug fixes 🐛
+
+- N/A
+
 ## 1.1.0
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -51,6 +51,7 @@ var subtag = require("subtag");
  * @param {Function} [options.getItemValue] A function that specifies how the selected result should be rendered in the search bar. This function should accept a single [Carmen GeoJSON](https://github.com/mapbox/carmen/blob/master/carmen-geojson.md) object as input and return a string. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
  * @param {Boolean} [options.localGeocoderOnly=false] If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher.
  * @param {Boolean} [options.showResultsWhileTyping=false] If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option.
+ * @param {Number} [options.debounceSearch=200] Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query.
  * @example
  *
  * var GeoApi = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,6 +112,7 @@ MaplibreGeocoder.prototype = {
       );
     },
     showResultMarkers: false,
+    debounceSearch: 200,
   },
 
   /**
@@ -229,7 +230,7 @@ MaplibreGeocoder.prototype = {
       this._inputEl.addEventListener("blur", this._onBlur);
     }
 
-    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, 200));
+    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, this.debounceSearch));
     this._inputEl.addEventListener("paste", this._onPaste);
     this._inputEl.addEventListener("change", this._onChange);
     this.container.addEventListener("mouseenter", this._showButton);


### PR DESCRIPTION
This is a minor addition I made that allows for a manual debounce before sending a query, while preserving the default value.

The code is identical to one I did for a minified LocationIQ geocoder. Please note that I have not tested it in maplibre (it works fine in the nearly-identical codebase of the LocationIQ geocoder JS file), but the code is incredibly simple, and I am offering it here to be polished (if needed), since it seems like a no-brainer feature.

I have no tests to offer, and wouldn't know how to write them. I hope this feature will be considered for use.

Thank you.

EDIT: I'm happy to do the other steps required for approval... I just need some direction in what to actually _do_.

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
