### PR TITLE
Use the correct debounce parameter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -231,7 +231,7 @@ MaplibreGeocoder.prototype = {
       this._inputEl.addEventListener("blur", this._onBlur);
     }
 
-    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, this.debounceSearch));
+    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, this.options.debounceSearch));
     this._inputEl.addEventListener("paste", this._onPaste);
     this._inputEl.addEventListener("change", this._onChange);
     this.container.addEventListener("mouseenter", this._showButton);


### PR DESCRIPTION
Debouncing was practically broken, as it used the incorrect parameter.

Related to #10 