### PR TITLE
Update to suggestions list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master
 
+- Switch from `suggestions` library to `suggestions-list`, change enter key logic to support selecting list items with enter key
+
 ## 1.1.1
 
 ### Features / Improvements 🚀

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ MaplibreGeocoder.prototype = {
         "</div></div>"
       );
     },
-    showResultMarkers: false,
+    showResultMarkers: true,
     debounceSearch: 200,
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var Typeahead = require("suggestions");
+var Typeahead = require("suggestions-list");
 var debounce = require("lodash.debounce");
 var extend = require("xtend");
 var EventEmitter = require("events").EventEmitter;
@@ -231,7 +231,10 @@ MaplibreGeocoder.prototype = {
       this._inputEl.addEventListener("blur", this._onBlur);
     }
 
-    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, this.debounceSearch));
+    this._inputEl.addEventListener(
+      "keydown",
+      debounce(this._onKeyDown, this.debounceSearch)
+    );
     this._inputEl.addEventListener("paste", this._onPaste);
     this._inputEl.addEventListener("change", this._onChange);
     this.container.addEventListener("mouseenter", this._showButton);
@@ -271,6 +274,7 @@ MaplibreGeocoder.prototype = {
       filter: false,
       minLength: this.options.minLength,
       limit: this.options.limit,
+      noInitialSelection: true,
     });
 
     this.setRenderFunction(this.options.render);
@@ -381,7 +385,8 @@ MaplibreGeocoder.prototype = {
     // ENTER
     if (e.keyCode === 13) {
       if (!this.options.showResultsWhileTyping) {
-        this._geocode(target.value);
+        if (!this._typeahead.list.selectingListItem)
+          this._geocode(target.value);
       } else {
         if (this.options.showResultMarkers) {
           this._fitBoundsForMarkers();

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash.debounce": "^4.0.6",
     "nanoid": "^2.0.1",
     "subtag": "^0.5.0",
-    "suggestions": "^1.6.0",
+    "suggestions-list": "^0.0.2",
     "xtend": "^4.0.1"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7695,10 +7695,10 @@ subtag@^0.5.0:
   resolved "https://registry.yarnpkg.com/subtag/-/subtag-0.5.0.tgz#1728a8df5257fb98ded4fb981b2ac7af10cf58ba"
   integrity sha512-CaIBcTSb/nyk4xiiSOtZYz1B+F12ZxW8NEp54CdT+84vmh/h4sUnHGC6+KQXUfED8u22PQjCYWfZny8d2ELXwg==
 
-suggestions@^1.6.0:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/suggestions/-/suggestions-1.7.1.tgz#2fefcbde8967353056d1d6eaed891b46d98a7e5c"
-  integrity sha512-gl5YPAhPYl07JZ5obiD9nTZsg4SyZswAQU/NNtnYiSnFkI3+ZHuXAiEsYm7AaZ71E0LXSFaGVaulGSWN3Gd71A==
+suggestions-list@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/suggestions-list/-/suggestions-list-0.0.2.tgz#3c5f501833e697a726a1bf58fbc454d57ffa0e98"
+  integrity sha512-Yw0fdq14c6RQWQIfE1/8WEi9Dp8rjyCD6FhYA/Tit2/ADbE9Y4ADG4ezlvivsa8Civ5nz++pyVVBMjOMlgIUJw==
   dependencies:
     fuzzy "^0.1.1"
     xtend "^4.0.0"


### PR DESCRIPTION
### Overview

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- Set `showResultMarkers` to `true` by default
- Change `suggestions` library to `suggestions-list`
  - `suggestions-list` forks `suggestions` to add feature support for not selecting any list items by default
- Update geocoder `enter` keypress behavior
  - Previously would set the list value to the selected item and redo search API call with that input
  - Now in the geocoder it will check if a list item is active
    - If list item is active then geocoder will not call search API and will list the suggestions-list set the value and hide list results
    - If there is no list item active it will do a geocoder search API call 

## Checklist

 - [x] briefly describe the changes in this PR
 - [x] update CHANGELOG.md with changes under `master` heading before merging
