### PR TITLE
Force showResultsWhileTyping on when getSuggestions API is included

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,8 @@ var subtag = require("subtag");
 
 function MaplibreGeocoder(geocoderApi, options) {
   this._eventEmitter = new EventEmitter();
+  options.showResultsWhileTyping =
+    !!geocoderApi.getSuggestions || options.showResultsWhileTyping; // Force showResultsWhileTyping to be on when suggestions API is passed in
   this.options = extend({}, this.options, options);
   this.inputString = "";
   this.fresh = true;

--- a/lib/index.js
+++ b/lib/index.js
@@ -763,7 +763,7 @@ MaplibreGeocoder.prototype = {
                 : res.features;
             this._typeahead.update(data);
             if (
-              !this.options.showResultsWhileTyping &&
+              (!this.options.showResultsWhileTyping || isSuggestion) &&
               this.options.showResultMarkers
             )
               this._fitBoundsForMarkers();


### PR DESCRIPTION
- If a getSuggestions API is passed in set `showResultsWhileTyping` to `true`
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [ ] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
