### PR TITLE
feat: suggestions API and UI feature

### DIFF
--- a/API.md
+++ b/API.md
@@ -111,6 +111,7 @@ A geocoder component that works with maplibre
 var GeoApi = {
   forwardGeocode: (config) => { return { features: [] } },
   reverseGeocode: (config) => { return { features: [] } }
+  getSuggestions: (config) => { return { suggestions: String[] }}
 }
 var geocoder = new MaplibreGeocoder(GeoApi, {});
 map.addControl(geocoder);

--- a/API.md
+++ b/API.md
@@ -104,7 +104,6 @@ A geocoder component that works with maplibre
     -   `options.localGeocoderOnly` **[Boolean][59]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher. (optional, default `false`)
     -   `options.showResultsWhileTyping` **[Boolean][59]** If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option. (optional, default `false`)
     -   `options.debounceSearch` **[Number][58]** Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query. (optional, default `200`)
-    -   `options.suggestionsOnlyWhileTyping` **[Boolean][59]** If `false` indicates that while typing `forwardGeocode` and `getSuggestions` API will be called and combined into the results list, if `true` only `getSuggestions` API will be called on typing. (optional, default `false`)
 
 ### Examples
 

--- a/API.md
+++ b/API.md
@@ -104,6 +104,7 @@ A geocoder component that works with maplibre
     -   `options.localGeocoderOnly` **[Boolean][59]** If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher. (optional, default `false`)
     -   `options.showResultsWhileTyping` **[Boolean][59]** If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option. (optional, default `false`)
     -   `options.debounceSearch` **[Number][58]** Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query. (optional, default `200`)
+    -   `options.suggestionsOnlyWhileTyping` **[Boolean][59]** If `false` indicates that while typing `forwardGeocode` and `getSuggestions` API will be called and combined into the results list, if `true` only `getSuggestions` API will be called on typing. (optional, default `false`)
 
 ### Examples
 
@@ -111,7 +112,7 @@ A geocoder component that works with maplibre
 var GeoApi = {
   forwardGeocode: (config) => { return { features: [] } },
   reverseGeocode: (config) => { return { features: [] } }
-  getSuggestions: (config) => { return { suggestions: String[] }}
+  getSuggestions: (config) => { return { suggestions: string[] }}
 }
 var geocoder = new MaplibreGeocoder(GeoApi, {});
 map.addControl(geocoder);

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,10 +165,12 @@ MaplibreGeocoder.prototype = {
       }
 
       // Filter out the suggestions that are already in the search results
-      const featureLabels = searchResults.map((feature) => feature.place_name);
-      const filteredSuggestions = suggestionResults.filter(
-        (result) => !featureLabels.includes(result)
-      );
+      const featureLabels = searchResults.map(function (feature) {
+        return feature.place_name;
+      });
+      const filteredSuggestions = suggestionResults.filter(function (result) {
+        return !featureLabels.includes(result);
+      });
 
       if (filteredSuggestions.length + searchResults.length >= limit) {
         // Restrict suggestions to < half of the limit at most

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,6 +158,44 @@ MaplibreGeocoder.prototype = {
         "</div></div>"
       );
     },
+    processResults: function (searchResults, suggestionResults, limit) {
+      if (!suggestionResults || suggestionResults.length === 0) {
+        return searchResults;
+      }
+
+      // Filter out the suggestions that are already in the search results
+      const featureLabels = searchResults.map((feature) => feature.place_name);
+      const filteredSuggestions = suggestionResults.filter(
+        (result) => !featureLabels.includes(result)
+      );
+
+      if (filteredSuggestions.length + searchResults.length >= limit) {
+        // Restrict suggestions to < half of the limit at most
+        let suggestionsLimit = Math.min(
+          filteredSuggestions.length,
+          Math.floor(limit / 2)
+        );
+        // If there are not enough results to fill to limit, add more suggestions
+        while (searchResults.length + suggestionsLimit < limit) {
+          suggestionsLimit++;
+        }
+
+        // Add the suggestions to the search results
+        const limitedResults = [];
+        for (let i = 0; i < suggestionsLimit; i++) {
+          limitedResults.push(filteredSuggestions[i]);
+        }
+        for (let i = 0; i < limit - suggestionsLimit; i++) {
+          limitedResults.push(searchResults[i]);
+        }
+
+        return limitedResults;
+      }
+
+      return filteredSuggestions.length > 0
+        ? filteredSuggestions.concat(searchResults)
+        : searchResults;
+    },
     showResultMarkers: true,
     debounceSearch: 200,
   },
@@ -319,7 +357,7 @@ MaplibreGeocoder.prototype = {
     this._typeahead = new Typeahead(this._inputEl, [], {
       filter: false,
       minLength: this.options.minLength,
-      limit: 10,
+      limit: this.options.limit,
       noInitialSelection: true,
     });
 
@@ -738,11 +776,14 @@ MaplibreGeocoder.prototype = {
           if (res.features.length) {
             this._clearEl.style.display = "block";
             this._eventEmitter.emit("results", res);
-            var data =
-              res.suggestions && res.suggestions.length > 0
-                ? res.features.concat(res.suggestions)
-                : res.features;
-            this._typeahead.update(data);
+
+            var processedResults = this.options.processResults(
+              res.features,
+              res.suggestions,
+              this.options.limit
+            );
+
+            this._typeahead.update(processedResults);
             if (
               (!this.options.showResultsWhileTyping || isSuggestion) &&
               this.options.showResultMarkers
@@ -978,7 +1019,12 @@ MaplibreGeocoder.prototype = {
   _fitBoundsForMarkers: function () {
     if (this._typeahead.data.length < 1) return;
 
-    var results = this._typeahead.data.slice(0, this.options.limit);
+    // Filter out suggestions and restrict to limit
+    var results = this._typeahead.data
+      .filter((result) => {
+        return typeof result === "string" ? false : true;
+      })
+      .slice(0, this.options.limit);
 
     this._clearEl.style.display = "none";
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -91,17 +91,26 @@ MaplibreGeocoder.prototype = {
     clearAndBlurOnEsc: false,
     clearOnBlur: false,
     getItemValue: function (item) {
-      return item.place_name;
+      return typeof item === "string" ? item : item.place_name;
     },
     render: function (item) {
-      var placeName = item.place_name.split(",");
-      return (
-        '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
-        placeName[0] +
-        '</div><div class="mapboxgl-ctrl-geocoder--suggestion-address maplibregl-ctrl-geocoder--suggestion-address">' +
-        placeName.splice(1, placeName.length).join(",") +
-        "</div></div>"
-      );
+      // Render as a suggestion
+      if (typeof item === "string") {
+        return (
+          '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
+          item +
+          "</div></div>"
+        );
+      } else {
+        var placeName = item.place_name.split(",");
+        return (
+          '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
+          placeName[0] +
+          '</div><div class="mapboxgl-ctrl-geocoder--suggestion-address maplibregl-ctrl-geocoder--suggestion-address">' +
+          placeName.splice(1, placeName.length).join(",") +
+          "</div></div>"
+        );
+      }
     },
     popupRender: function (item) {
       var placeName = item.place_name.split(",");
@@ -274,7 +283,7 @@ MaplibreGeocoder.prototype = {
     this._typeahead = new Typeahead(this._inputEl, [], {
       filter: false,
       minLength: this.options.minLength,
-      limit: this.options.limit,
+      limit: 10,
       noInitialSelection: true,
     });
 
@@ -425,7 +434,13 @@ MaplibreGeocoder.prototype = {
   },
   _onChange: function () {
     var selected = this._typeahead.selected;
-    if (selected && JSON.stringify(selected) !== this.lastSelected) {
+
+    // If a suggestion was selected
+    if (selected && typeof selected === "string") {
+      console.log("suggestionsselected");
+      this._geocode(selected);
+      // If an address was selected
+    } else if (selected && JSON.stringify(selected) !== this.lastSelected) {
       this._clearEl.style.display = "none";
       if (this.options.flyTo) {
         var flyOptions;
@@ -674,8 +689,7 @@ MaplibreGeocoder.prototype = {
           if (res.features.length) {
             this._clearEl.style.display = "block";
             this._eventEmitter.emit("results", res);
-            console.log(res.suggestions);
-            this._typeahead.update(res.features);
+            this._typeahead.update(res.features.concat(res.suggestions));
             if (
               !this.options.showResultsWhileTyping &&
               this.options.showResultMarkers

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ var subtag = require("subtag");
  * var GeoApi = {
  *   forwardGeocode: (config) => { return { features: [] } },
  *   reverseGeocode: (config) => { return { features: [] } }
- *   getSuggestions: (config) => { return { suggestions: String[] }}
+ *   getSuggestions: (config) => { return { suggestions: string[] }}
  * }
  * var geocoder = new MaplibreGeocoder(GeoApi, {});
  * map.addControl(geocoder);

--- a/lib/index.js
+++ b/lib/index.js
@@ -479,15 +479,14 @@ MaplibreGeocoder.prototype = {
           this._geocode(target.value);
         }
       } else {
-        // If pressing enter while the input box is selected and suggestions is enabled
-        // If pressing enter while selected on an item _onChange handler will take care of it
+        // Pressing enter on the search box will do a search for the currently string input
         if (
           this._typeahead.selected == null &&
           this.geocoderApi.getSuggestions
         ) {
           this._geocode(target.value, true);
 
-          // If pressing enter while the input box is selected and suggestions is disabled
+          // If suggestions API is not defined pressing enter while the input box is selected will try to fit the results into the current map view
         } else if (this._typeahead.selected == null) {
           if (this.options.showResultMarkers) {
             this._fitBoundsForMarkers();

--- a/lib/index.js
+++ b/lib/index.js
@@ -395,24 +395,56 @@ MaplibreGeocoder.prototype = {
     // ENTER
     if (e.keyCode === 13) {
       if (!this.options.showResultsWhileTyping) {
-        if (!this._typeahead.list.selectingListItem)
+        if (!this._typeahead.selected) {
           this._geocode(target.value);
-      } else {
-        if (this.options.showResultMarkers) {
-          this._fitBoundsForMarkers();
         }
-        this._inputEl.value = this._typeahead.query;
-        this.lastSelected = null;
-        this._typeahead.selected = null;
+      } else {
+        // If pressing enter while the input box is selected and suggestions is enabled
+        // If pressing enter while selected on an item _onChange handler will take care of it
+        if (
+          this._typeahead.selected == null &&
+          this.geocoderApi.getSuggestions
+        ) {
+          if (typeof this._typeahead.data[0] === "string") {
+            this.setInput(this._typeahead.data[0]);
+          }
+
+          // If pressing enter while the input box is selected and suggestions is disabled
+        } else if (this._typeahead.selected == null) {
+          if (this.options.showResultMarkers) {
+            this._fitBoundsForMarkers();
+          }
+        }
         return;
       }
     }
 
+    // Show results while typing and greater than min length
     if (
       target.value.length >= this.options.minLength &&
       this.options.showResultsWhileTyping
     ) {
-      this._geocode(target.value);
+      // only show suggestions when typing
+      if (this.geocoderApi.getSuggestions) {
+        var suggestions = this._getSuggestions(target.value) || [];
+        suggestions
+          .then(
+            function (response) {
+              this._clearEl.style.display = "block";
+              this._eventEmitter.emit("resultsSuggestions", response);
+              this._typeahead.update(response);
+            }.bind(this)
+          )
+          .catch(
+            function (err) {
+              this._eventEmitter.emit("error", { error: err });
+            }.bind(this)
+          );
+
+        // Perform search while typing
+      } else {
+        this._geocode(target.value);
+      }
     }
   },
 
@@ -437,7 +469,6 @@ MaplibreGeocoder.prototype = {
 
     // If a suggestion was selected
     if (selected && typeof selected === "string") {
-      console.log("suggestionsselected");
       this._geocode(selected, true);
       // If an address was selected
     } else if (selected && JSON.stringify(selected) !== this.lastSelected) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -96,19 +96,53 @@ MaplibreGeocoder.prototype = {
     render: function (item) {
       // Render as a suggestion
       if (typeof item === "string") {
+        var suggestionName = item.split(",");
+        var indexOfMatch = suggestionName[0]
+          .toLowerCase()
+          .indexOf(this.query.toLowerCase());
+        var lengthOfMatch = this.query.length;
+        var beforeMatch = suggestionName[0].substring(0, indexOfMatch);
+        var match = suggestionName[0].substring(
+          indexOfMatch,
+          indexOfMatch + lengthOfMatch
+        );
+        var afterMatch = suggestionName[0].substring(
+          indexOfMatch + lengthOfMatch
+        );
+
         return (
-          '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
-          item +
-          "</div></div>"
+          '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion">' +
+          '<svg class="mapboxgl-ctrl-geocoder--suggestion-icon maplibre-ctrl-geocoder--suggestion-icon" viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg"><path d="M22.8702 20.1258H21.4248L20.9125 19.6318C22.7055 17.546 23.785 14.8382 23.785 11.8925C23.785 5.32419 18.4608 0 11.8925 0C5.32419 0 0 5.32419 0 11.8925C0 18.4608 5.32419 23.785 11.8925 23.785C14.8382 23.785 17.546 22.7055 19.6318 20.9125L20.1258 21.4248V22.8702L29.2739 32L32 29.2739L22.8702 20.1258ZM11.8925 20.1258C7.33676 20.1258 3.65923 16.4483 3.65923 11.8925C3.65923 7.33676 7.33676 3.65923 11.8925 3.65923C16.4483 3.65923 20.1258 7.33676 20.1258 11.8925C20.1258 16.4483 16.4483 20.1258 11.8925 20.1258Z" fill="#687078"/></svg>' +
+          '<div class="mapboxgl-ctrl-geocoder--suggestion-info maplibregl-ctrl-geocoder--suggestion-info">' +
+          '<div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
+          beforeMatch +
+          '<span class="mapboxgl-ctrl-geocoder--suggestion-match maplibregl-ctrl-geocoder--suggestion-match">' +
+          match +
+          "</span>" +
+          afterMatch +
+          "</div>" +
+          '<div class="mapboxgl-ctrl-geocoder--suggestion-address maplibregl-ctrl-geocoder--suggestion-address">' +
+          suggestionName.splice(1, suggestionName.length).join(",") +
+          "</div>" +
+          "</div>" +
+          "</div>"
         );
       } else {
+        // render as a search result
         var placeName = item.place_name.split(",");
+
         return (
-          '<div class="mapboxgl-ctrl-geocoder--suggestion maplibregl-ctrl-geocoder--suggestion"><div class="mapboxgl-ctrl-geocoder--suggestion-title maplibregl-ctrl-geocoder--suggestion-title">' +
+          '<div class="mapboxgl-ctrl-geocoder--result maplibregl-ctrl-geocoder--result">' +
+          '<svg class="mapboxgl-ctrl-geocoder--result-icon maplibre-ctrl-geocoder--result-icon" viewBox="0 0 24 32" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 0C5.36571 0 0 5.38676 0 12.0471C0 21.0824 12 32 12 32C12 32 24 21.0824 24 12.0471C24 5.38676 18.6343 0 12 0ZM12 16.3496C9.63428 16.3496 7.71429 14.4221 7.71429 12.0471C7.71429 9.67207 9.63428 7.74454 12 7.74454C14.3657 7.74454 16.2857 9.67207 16.2857 12.0471C16.2857 14.4221 14.3657 16.3496 12 16.3496Z" fill="#687078"/></svg>' +
+          "<div>" +
+          '<div class="mapboxgl-ctrl-geocoder--result-title maplibregl-ctrl-geocoder--result-title">' +
           placeName[0] +
-          '</div><div class="mapboxgl-ctrl-geocoder--suggestion-address maplibregl-ctrl-geocoder--suggestion-address">' +
+          "</div>" +
+          '<div class="mapboxgl-ctrl-geocoder--result-address maplibregl-ctrl-geocoder--result-address">' +
           placeName.splice(1, placeName.length).join(",") +
-          "</div></div>"
+          "</div>" +
+          "</div>" +
+          "</div>"
         );
       }
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -186,12 +186,11 @@ MaplibreGeocoder.prototype = {
           limitedResults.push(filteredSuggestions[i]);
         }
         for (var idx = 0; idx < limit - suggestionsLimit; idx++) {
-          limitedResults.push(searchResults[i]);
+          limitedResults.push(searchResults[idx]);
         }
 
         return limitedResults;
       }
-
       return filteredSuggestions.length > 0
         ? filteredSuggestions.concat(searchResults)
         : searchResults;

--- a/lib/index.js
+++ b/lib/index.js
@@ -57,6 +57,7 @@ var subtag = require("subtag");
  * var GeoApi = {
  *   forwardGeocode: (config) => { return { features: [] } },
  *   reverseGeocode: (config) => { return { features: [] } }
+ *   getSuggestions: (config) => { return { suggestions: String[] }}
  * }
  * var geocoder = new MaplibreGeocoder(GeoApi, {});
  * map.addControl(geocoder);
@@ -231,8 +232,10 @@ MaplibreGeocoder.prototype = {
       this._inputEl.addEventListener("blur", this._onBlur);
     }
 
-
-    this._inputEl.addEventListener("keydown", debounce(this._onKeyDown, this.options.debounceSearch));
+    this._inputEl.addEventListener(
+      "keydown",
+      debounce(this._onKeyDown, this.options.debounceSearch)
+    );
     this._inputEl.addEventListener("paste", this._onPaste);
     this._inputEl.addEventListener("change", this._onChange);
     this.container.addEventListener("mouseenter", this._showButton);
@@ -489,10 +492,7 @@ MaplibreGeocoder.prototype = {
     }
   },
 
-  _geocode: function (searchInput) {
-    this._loadingEl.style.display = "block";
-    this._eventEmitter.emit("loading", { query: searchInput });
-    this.inputString = searchInput;
+  _getConfigForRequest: function () {
     // Possible config proprerties to pass to client
     var keys = [
       "bbox",
@@ -504,7 +504,6 @@ MaplibreGeocoder.prototype = {
       "reverseMode",
     ];
     var self = this;
-    var geocoderError = null;
     // Create config object
     var config = keys.reduce(function (config, key) {
       if (self.options[key]) {
@@ -528,6 +527,18 @@ MaplibreGeocoder.prototype = {
       }
       return config;
     }, {});
+
+    return config;
+  },
+
+  _geocode: async function (searchInput) {
+    this._loadingEl.style.display = "block";
+    this._eventEmitter.emit("loading", { query: searchInput });
+    this.inputString = searchInput;
+    var geocoderError = null;
+
+    // Create config object
+    var config = this._getConfigForRequest();
 
     var request;
     if (this.options.localGeocoderOnly) {
@@ -560,6 +571,7 @@ MaplibreGeocoder.prototype = {
       request = this.geocoderApi.reverseGeocode(config);
     } else {
       config = extend(config, { query: searchInput });
+
       request = this.geocoderApi.forwardGeocode(config);
     }
 
@@ -571,6 +583,12 @@ MaplibreGeocoder.prototype = {
       }
     }
     var externalGeocoderRes = [];
+
+    let suggestions = [];
+    if (this._getSuggestions && typeof this._getSuggestions == "function") {
+      suggestions = await this._getSuggestions(searchInput);
+    }
+    console.log(suggestions);
 
     request
       .catch(
@@ -679,6 +697,26 @@ MaplibreGeocoder.prototype = {
       );
 
     return request;
+  },
+
+  _getSuggestions: async function (searchInput) {
+    if (!this.geocoderApi.getSuggestions) {
+      return;
+    }
+    // Create config object
+    var config = this._getConfigForRequest();
+    config = extend(config, { query: searchInput });
+
+    try {
+      this._eventEmitter.emit("loadingSuggestions", { query: searchInput });
+      const response = await this.geocoderApi.getSuggestions(config);
+      this._eventEmitter.emit("resultsSuggestions", response.suggestions);
+
+      return response.suggestions;
+    } catch (error) {
+      this._eventEmitter.emit("error", { error });
+      return [];
+    }
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -531,7 +531,7 @@ MaplibreGeocoder.prototype = {
     return config;
   },
 
-  _geocode: async function (searchInput) {
+  _geocode: function (searchInput) {
     this._loadingEl.style.display = "block";
     this._eventEmitter.emit("loading", { query: searchInput });
     this.inputString = searchInput;
@@ -584,11 +584,7 @@ MaplibreGeocoder.prototype = {
     }
     var externalGeocoderRes = [];
 
-    let suggestions = [];
-    if (this._getSuggestions && typeof this._getSuggestions == "function") {
-      suggestions = await this._getSuggestions(searchInput);
-    }
-    console.log(suggestions);
+    var suggestions = [];
 
     request
       .catch(
@@ -643,6 +639,24 @@ MaplibreGeocoder.prototype = {
               }
             );
           }
+
+          if (this.geocoderApi.getSuggestions) {
+            suggestions = this._getSuggestions(searchInput) || [];
+            // supplement Geocoding API results with features returned by a promise
+            return suggestions.then(
+              function (response) {
+                if (response.length > 0) {
+                  res.suggestions = response;
+                }
+                return res;
+              },
+              function () {
+                // on error, display the original result
+                return res;
+              }
+            );
+          }
+
           return res;
         }.bind(this)
       )
@@ -660,6 +674,7 @@ MaplibreGeocoder.prototype = {
           if (res.features.length) {
             this._clearEl.style.display = "block";
             this._eventEmitter.emit("results", res);
+            console.log(res.suggestions);
             this._typeahead.update(res.features);
             if (
               !this.options.showResultsWhileTyping &&
@@ -699,24 +714,50 @@ MaplibreGeocoder.prototype = {
     return request;
   },
 
-  _getSuggestions: async function (searchInput) {
-    if (!this.geocoderApi.getSuggestions) {
-      return;
-    }
-    // Create config object
-    var config = this._getConfigForRequest();
-    config = extend(config, { query: searchInput });
+  _getSuggestions: function (searchInput) {
+    return new Promise(
+      function (resolve, reject) {
+        if (!this.geocoderApi.getSuggestions) {
+          reject();
+        }
 
-    try {
-      this._eventEmitter.emit("loadingSuggestions", { query: searchInput });
-      const response = await this.geocoderApi.getSuggestions(config);
-      this._eventEmitter.emit("resultsSuggestions", response.suggestions);
+        this._eventEmitter.emit("loadingSuggestions", { query: searchInput });
+        var getSuggestionsError = null;
+        var suggestions = [];
 
-      return response.suggestions;
-    } catch (error) {
-      this._eventEmitter.emit("error", { error });
-      return [];
-    }
+        // Create config object
+        var config = this._getConfigForRequest();
+        config = extend(config, { query: searchInput });
+
+        var request;
+        request = this.geocoderApi.getSuggestions(config);
+
+        request
+          .catch(
+            function (error) {
+              getSuggestionsError = error;
+            }.bind(this)
+          )
+          .then(
+            function (res) {
+              if (getSuggestionsError) {
+                throw getSuggestionsError;
+              }
+
+              if (res.suggestions.length) {
+                suggestions = res.suggestions;
+              }
+              resolve(suggestions);
+              this._eventEmitter.emit("resultsSuggestions", res.suggestions);
+            }.bind(this)
+          )
+          .catch(
+            function (err) {
+              this._eventEmitter.emit("error", { error: err });
+            }.bind(this)
+          );
+      }.bind(this)
+    );
   },
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,6 +52,7 @@ var subtag = require("subtag");
  * @param {Boolean} [options.localGeocoderOnly=false] If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher.
  * @param {Boolean} [options.showResultsWhileTyping=false] If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option.
  * @param {Number} [options.debounceSearch=200] Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query.
+ * @param {Boolean} [options.suggestionsOnlyWhileTyping=false] If `false` indicates that while typing `forwardGeocode` and `getSuggestions` API will be called and combined into the results list, if `true` only `getSuggestions` API will be called on typing.
  * @example
  *
  * var GeoApi = {
@@ -198,6 +199,7 @@ MaplibreGeocoder.prototype = {
     },
     showResultMarkers: true,
     debounceSearch: 200,
+    suggestionsOnlyWhileTyping: false,
   },
 
   /**
@@ -496,8 +498,28 @@ MaplibreGeocoder.prototype = {
       target.value.length >= this.options.minLength &&
       this.options.showResultsWhileTyping
     ) {
-      // only show suggestions when typing
-      if (this.geocoderApi.getSuggestions) {
+      // Only call getSuggestions if suggestionsOnlyWhileTyping is true
+      if (
+        this.geocoderApi.getSuggestions &&
+        this.options.suggestionsOnlyWhileTyping
+      ) {
+        var suggestions = this._getSuggestions(target.value) || [];
+        suggestions
+          .then(
+            function (response) {
+              this._clearEl.style.display = "block";
+              this._eventEmitter.emit("resultsSuggestions", response);
+              this._typeahead.update(response);
+            }.bind(this)
+          )
+          .catch(
+            function (err) {
+              this._eventEmitter.emit("error", { error: err });
+            }.bind(this)
+          );
+
+        // Perform search and getSuggestions while typing
+      } else {
         this._geocode(target.value);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,6 @@ var subtag = require("subtag");
  * @param {Boolean} [options.localGeocoderOnly=false] If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher.
  * @param {Boolean} [options.showResultsWhileTyping=false] If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option.
  * @param {Number} [options.debounceSearch=200] Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query.
- * @param {Boolean} [options.suggestionsOnlyWhileTyping=false] If `false` indicates that while typing `forwardGeocode` and `getSuggestions` API will be called and combined into the results list, if `true` only `getSuggestions` API will be called on typing.
  * @example
  *
  * var GeoApi = {
@@ -67,10 +66,6 @@ var subtag = require("subtag");
  */
 
 function MaplibreGeocoder(geocoderApi, options) {
-  if (options) {
-    options.showResultsWhileTyping =
-      !!geocoderApi.getSuggestions || options.showResultsWhileTyping;
-  }
   this._eventEmitter = new EventEmitter();
   this.options = extend({}, this.options, options);
   this.inputString = "";
@@ -203,7 +198,6 @@ MaplibreGeocoder.prototype = {
     },
     showResultMarkers: true,
     debounceSearch: 200,
-    suggestionsOnlyWhileTyping: false,
   },
 
   /**
@@ -501,30 +495,7 @@ MaplibreGeocoder.prototype = {
       target.value.length >= this.options.minLength &&
       this.options.showResultsWhileTyping
     ) {
-      // Only call getSuggestions if suggestionsOnlyWhileTyping is true
-      if (
-        this.geocoderApi.getSuggestions &&
-        this.options.suggestionsOnlyWhileTyping
-      ) {
-        var suggestions = this._getSuggestions(target.value) || [];
-        suggestions
-          .then(
-            function (response) {
-              this._clearEl.style.display = "block";
-              this._eventEmitter.emit("resultsSuggestions", response);
-              this._typeahead.update(response);
-            }.bind(this)
-          )
-          .catch(
-            function (err) {
-              this._eventEmitter.emit("error", { error: err });
-            }.bind(this)
-          );
-
-        // Perform search and getSuggestions while typing
-      } else {
-        this._geocode(target.value);
-      }
+      this._geocode(target.value);
     }
   },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -441,9 +441,7 @@ MaplibreGeocoder.prototype = {
           this._typeahead.selected == null &&
           this.geocoderApi.getSuggestions
         ) {
-          if (typeof this._typeahead.data[0] === "string") {
-            this.setInput(this._typeahead.data[0]);
-          }
+          this._geocode(target.value, true);
 
           // If pressing enter while the input box is selected and suggestions is disabled
         } else if (this._typeahead.selected == null) {
@@ -462,23 +460,6 @@ MaplibreGeocoder.prototype = {
     ) {
       // only show suggestions when typing
       if (this.geocoderApi.getSuggestions) {
-        var suggestions = this._getSuggestions(target.value) || [];
-        suggestions
-          .then(
-            function (response) {
-              this._clearEl.style.display = "block";
-              this._eventEmitter.emit("resultsSuggestions", response);
-              this._typeahead.update(response);
-            }.bind(this)
-          )
-          .catch(
-            function (err) {
-              this._eventEmitter.emit("error", { error: err });
-            }.bind(this)
-          );
-
-        // Perform search while typing
-      } else {
         this._geocode(target.value);
       }
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,7 @@ MaplibreGeocoder.prototype = {
         return !featureLabels.includes(result);
       });
 
-      if (filteredSuggestions.length + searchResults.length >= limit) {
+      if (filteredSuggestions.length + searchResults.length > limit) {
         // Restrict suggestions to < half of the limit at most
         var suggestionsLimit = Math.min(
           filteredSuggestions.length,

--- a/lib/index.js
+++ b/lib/index.js
@@ -162,16 +162,16 @@ MaplibreGeocoder.prototype = {
       }
 
       // Filter out the suggestions that are already in the search results
-      const featureLabels = searchResults.map(function (feature) {
+      var featureLabels = searchResults.map(function (feature) {
         return feature.place_name;
       });
-      const filteredSuggestions = suggestionResults.filter(function (result) {
+      var filteredSuggestions = suggestionResults.filter(function (result) {
         return !featureLabels.includes(result);
       });
 
       if (filteredSuggestions.length + searchResults.length >= limit) {
         // Restrict suggestions to < half of the limit at most
-        let suggestionsLimit = Math.min(
+        var suggestionsLimit = Math.min(
           filteredSuggestions.length,
           Math.floor(limit / 2)
         );
@@ -181,11 +181,11 @@ MaplibreGeocoder.prototype = {
         }
 
         // Add the suggestions to the search results
-        const limitedResults = [];
-        for (let i = 0; i < suggestionsLimit; i++) {
+        var limitedResults = [];
+        for (var i = 0; i < suggestionsLimit; i++) {
           limitedResults.push(filteredSuggestions[i]);
         }
-        for (let i = 0; i < limit - suggestionsLimit; i++) {
+        for (var idx = 0; idx < limit - suggestionsLimit; idx++) {
           limitedResults.push(searchResults[i]);
         }
 
@@ -229,7 +229,7 @@ MaplibreGeocoder.prototype = {
           "Element provided to #addTo() exists, but is not in the DOM"
         );
       }
-      const el = geocoder.onAdd(); //returns the input elements, which are then added to the requested html container
+      var el = geocoder.onAdd(); //returns the input elements, which are then added to the requested html container
       container.appendChild(el);
     }
 
@@ -244,7 +244,7 @@ MaplibreGeocoder.prototype = {
     }
     // if the container is a string, treat it as a CSS query
     else if (typeof container == "string") {
-      const parent = document.querySelectorAll(container);
+      var parent = document.querySelectorAll(container);
       if (parent.length === 0) {
         throw new Error("Element ", container, "not found.");
       }
@@ -1019,7 +1019,7 @@ MaplibreGeocoder.prototype = {
 
     // Filter out suggestions and restrict to limit
     var results = this._typeahead.data
-      .filter((result) => {
+      .filter(function (result) {
         return typeof result === "string" ? false : true;
       })
       .slice(0, this.options.limit);

--- a/lib/index.js
+++ b/lib/index.js
@@ -438,7 +438,7 @@ MaplibreGeocoder.prototype = {
     // If a suggestion was selected
     if (selected && typeof selected === "string") {
       console.log("suggestionsselected");
-      this._geocode(selected);
+      this._geocode(selected, true);
       // If an address was selected
     } else if (selected && JSON.stringify(selected) !== this.lastSelected) {
       this._clearEl.style.display = "none";
@@ -546,7 +546,7 @@ MaplibreGeocoder.prototype = {
     return config;
   },
 
-  _geocode: function (searchInput) {
+  _geocode: function (searchInput, isSuggestion) {
     this._loadingEl.style.display = "block";
     this._eventEmitter.emit("loading", { query: searchInput });
     this.inputString = searchInput;
@@ -655,7 +655,8 @@ MaplibreGeocoder.prototype = {
             );
           }
 
-          if (this.geocoderApi.getSuggestions) {
+          // Only getSuggestions if the API exists and the query is not from a suggestion
+          if (this.geocoderApi.getSuggestions && !isSuggestion) {
             suggestions = this._getSuggestions(searchInput) || [];
             // supplement Geocoding API results with features returned by a promise
             return suggestions.then(
@@ -689,7 +690,11 @@ MaplibreGeocoder.prototype = {
           if (res.features.length) {
             this._clearEl.style.display = "block";
             this._eventEmitter.emit("results", res);
-            this._typeahead.update(res.features.concat(res.suggestions));
+            var data =
+              res.suggestions && res.suggestions.length > 0
+                ? res.features.concat(res.suggestions)
+                : res.features;
+            this._typeahead.update(data);
             if (
               !this.options.showResultsWhileTyping &&
               this.options.showResultMarkers

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,9 +67,11 @@ var subtag = require("subtag");
  */
 
 function MaplibreGeocoder(geocoderApi, options) {
+  if (options) {
+    options.showResultsWhileTyping =
+      !!geocoderApi.getSuggestions || options.showResultsWhileTyping;
+  }
   this._eventEmitter = new EventEmitter();
-  options.showResultsWhileTyping =
-    !!geocoderApi.getSuggestions || options.showResultsWhileTyping; // Force showResultsWhileTyping to be on when suggestions API is passed in
   this.options = extend({}, this.options, options);
   this.inputString = "";
   this.fresh = true;
@@ -807,6 +809,8 @@ MaplibreGeocoder.prototype = {
               this.options.limit
             );
 
+            this._eventEmitter.emit("processedResults", processedResults);
+
             this._typeahead.update(processedResults);
             if (
               (!this.options.showResultsWhileTyping || isSuggestion) &&
@@ -880,7 +884,7 @@ MaplibreGeocoder.prototype = {
                 suggestions = res.suggestions;
               }
               resolve(suggestions);
-              this._eventEmitter.emit("resultsSuggestions", res.suggestions);
+              this._eventEmitter.emit("resultsSuggestions", res);
             }.bind(this)
           )
           .catch(

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,8 @@ var subtag = require("subtag");
 
 function MaplibreGeocoder(geocoderApi, options) {
   this._eventEmitter = new EventEmitter();
+  options.showResultsWhileTyping =
+    !!geocoderApi.getSuggestions || options.showResultsWhileTyping; // Force showResultsWhileTyping to be on when suggestions API is passed in
   this.options = extend({}, this.options, options);
   this.inputString = "";
   this.fresh = true;
@@ -761,7 +763,7 @@ MaplibreGeocoder.prototype = {
                 : res.features;
             this._typeahead.update(data);
             if (
-              !this.options.showResultsWhileTyping &&
+              (!this.options.showResultsWhileTyping || isSuggestion) &&
               this.options.showResultMarkers
             )
               this._fitBoundsForMarkers();

--- a/lib/maplibre-gl-geocoder.css
+++ b/lib/maplibre-gl-geocoder.css
@@ -104,12 +104,56 @@
   cursor: pointer;
 }
 
-.maplibregl-ctrl-geocoder--suggestion-title {
+.maplibregl-ctrl-geocoder--suggestion {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.maplibre-ctrl-geocoder--suggestion-icon {
+  min-width: 30px;
+  min-height: 24px;
+  max-width: 30px;
+  max-height: 24px;
+  padding-right: 12px;
+}
+
+.maplibregl-ctrl-geocoder--suggestion-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.maplibregl-ctrl-geocoder--suggestion-match {
   font-weight: bold;
 }
 
 .maplibregl-ctrl-geocoder--suggestion-title,
 .maplibregl-ctrl-geocoder--suggestion-address {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.maplibregl-ctrl-geocoder--result {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.maplibre-ctrl-geocoder--result-icon {
+  min-width: 30px;
+  min-height: 24px;
+  max-width: 30px;
+  max-height: 24px;
+  padding-right: 12px;
+}
+
+.maplibregl-ctrl-geocoder--result-title {
+  font-weight: bold;
+}
+
+.maplibregl-ctrl-geocoder--result-title,
+.maplibregl-ctrl-geocoder--result-address {
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -1725,6 +1725,7 @@ test("geocoder", function (tt) {
       ),
       proximity: { longitude: -79.45, latitude: 43.65 },
       features: [Features.QUEEN_STREET],
+      showResultsWhileTyping: true,
     });
     geocoder.setInput("anything");
     geocoder.on(
@@ -1736,38 +1737,35 @@ test("geocoder", function (tt) {
     );
   });
 
-  tt.test(
-    "set input with suggestions, showResultsWhileTyping cannot be turned off if a suggestion API is included",
-    function (t) {
-      t.plan(3);
-      setup({
-        geocoderApi: mockGeocoderApiWithSuggestions(
-          [Features.QUEEN_STREET],
-          ["starbucks"]
-        ),
-        proximity: { longitude: -79.45, latitude: 43.65 },
-        features: [Features.QUEEN_STREET],
-        showResultsWhileTyping: false,
-      });
-      geocoder.setInput("anything");
-      geocoder.on(
-        "results",
-        once(function (e) {
-          t.ok(e.features, "features are in the event object");
-          t.ok(e.suggestions, "suggestions is in the response object");
-        })
-      );
-      geocoder.on(
-        "processedResults",
-        once(function (e) {
-          t.ok(
-            e.length === 2,
-            "processed results includes both search results and suggestions"
-          );
-        })
-      );
-    }
-  );
+  tt.test("query with suggestions", function (t) {
+    t.plan(3);
+    setup({
+      geocoderApi: mockGeocoderApiWithSuggestions(
+        [Features.QUEEN_STREET],
+        ["starbucks"]
+      ),
+      proximity: { longitude: -79.45, latitude: 43.65 },
+      features: [Features.QUEEN_STREET],
+      showResultsWhileTyping: false,
+    });
+    geocoder.query("anything");
+    geocoder.on(
+      "results",
+      once(function (e) {
+        t.ok(e.features, "features are in the event object");
+        t.ok(e.suggestions, "suggestions is in the response object");
+      })
+    );
+    geocoder.on(
+      "processedResults",
+      once(function (e) {
+        t.ok(
+          e.length === 2,
+          "processed results includes both search results and suggestions"
+        );
+      })
+    );
+  });
 
   tt.test(
     "set input with suggestions, manually set processResults",
@@ -1786,7 +1784,7 @@ test("geocoder", function (tt) {
         ),
         proximity: { longitude: -79.45, latitude: 43.65 },
         features: [Features.QUEEN_STREET],
-        showResultsWhileTyping: false,
+        showResultsWhileTyping: true,
         processResults,
       });
       geocoder.setInput("anything");

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -29,12 +29,41 @@ test("geocoder", function (tt) {
     };
   };
 
+  var mockGeocoderApiWithSuggestions = (
+    features,
+    suggestions,
+    errorMessage
+  ) => {
+    return {
+      forwardGeocode: async () => {
+        return new Promise(async (resolve, reject) => {
+          if (errorMessage) reject(errorMessage);
+          resolve({ features: features || [] });
+        });
+      },
+      reverseGeocode: async () => {
+        return new Promise(async (resolve, reject) => {
+          if (errorMessage) reject(errorMessage);
+          resolve({ features: features || [] });
+        });
+      },
+      getSuggestions: async () => {
+        return new Promise(async (resolve, reject) => {
+          if (errorMessage) reject(errorMessage);
+          resolve({ suggestions: suggestions || [] });
+        });
+      },
+    };
+  };
+
   function setup(opts) {
     opts = opts || {};
     opts.enableEventLogging = false;
     container = document.createElement("div");
     map = new maplibregl.Map({ container: container });
-    geocoderApi = mockGeocoderApi(opts.features, opts.errorMessage);
+    geocoderApi =
+      opts.geocoderApi ||
+      mockGeocoderApi(opts.features, opts.errorMessage, opts.suggestions);
     geocoder = new MapboxGeocoder(geocoderApi, opts);
     map.addControl(geocoder);
   }
@@ -1569,7 +1598,7 @@ test("geocoder", function (tt) {
       // no access token here
       container = document.createElement("div");
       map = new maplibregl.Map({ container: container });
-      geocoder = new MapboxGeocoder(opts);
+      geocoder = new MapboxGeocoder({}, opts);
       t.doesNotThrow(function () {
         map.addControl(geocoder);
       }, "does not throw an error when no access token is set");
@@ -1653,6 +1682,125 @@ test("geocoder", function (tt) {
     searchMock.restore();
     t.end();
   });
+
+  tt.test("query with suggestions", function (t) {
+    t.plan(5);
+    setup({
+      geocoderApi: mockGeocoderApiWithSuggestions(
+        [Features.QUEEN_STREET],
+        ["starbucks"]
+      ),
+      proximity: { longitude: -79.45, latitude: 43.65 },
+      features: [Features.QUEEN_STREET],
+    });
+    geocoder.query("Queen Street");
+    var mapMoveSpy = sinon.spy(map, "flyTo");
+    geocoder.on(
+      "result",
+      once(function (e) {
+        t.ok(e.result, "feature is in the event object");
+        var mapMoveArgs = mapMoveSpy.args[0][0];
+        t.ok(
+          mapMoveSpy.calledOnce,
+          "the map#flyTo method was called when a result was selected"
+        );
+        t.notEquals(mapMoveArgs.center[0], 0, "center.lng changed");
+        t.notEquals(mapMoveArgs.center[1], 0, "center.lat changed");
+      })
+    );
+    geocoder.on(
+      "resultsSuggestions",
+      once(function (e) {
+        t.ok(e.suggestions, "suggestions is in the response object");
+      })
+    );
+  });
+
+  tt.test("set input with suggestions", function (t) {
+    t.plan(2);
+    setup({
+      geocoderApi: mockGeocoderApiWithSuggestions(
+        [Features.QUEEN_STREET],
+        ["starbucks"]
+      ),
+      proximity: { longitude: -79.45, latitude: 43.65 },
+      features: [Features.QUEEN_STREET],
+    });
+    geocoder.setInput("anything");
+    geocoder.on(
+      "results",
+      once(function (e) {
+        t.ok(e.features, "features are in the event object");
+        t.ok(e.suggestions, "suggestions is in the response object");
+      })
+    );
+  });
+
+  tt.test(
+    "set input with suggestions, showResultsWhileTyping cannot be turned off if a suggestion API is included",
+    function (t) {
+      t.plan(3);
+      setup({
+        geocoderApi: mockGeocoderApiWithSuggestions(
+          [Features.QUEEN_STREET],
+          ["starbucks"]
+        ),
+        proximity: { longitude: -79.45, latitude: 43.65 },
+        features: [Features.QUEEN_STREET],
+        showResultsWhileTyping: false,
+      });
+      geocoder.setInput("anything");
+      geocoder.on(
+        "results",
+        once(function (e) {
+          t.ok(e.features, "features are in the event object");
+          t.ok(e.suggestions, "suggestions is in the response object");
+        })
+      );
+      geocoder.on(
+        "processedResults",
+        once(function (e) {
+          t.ok(
+            e.length === 2,
+            "processed results includes both search results and suggestions"
+          );
+        })
+      );
+    }
+  );
+
+  tt.test(
+    "set input with suggestions, manually set processResults",
+    function (t) {
+      t.plan(1);
+
+      var staticResults = ["staticResult"];
+      var processResults = function () {
+        return staticResults;
+      };
+
+      setup({
+        geocoderApi: mockGeocoderApiWithSuggestions(
+          [Features.QUEEN_STREET],
+          ["starbucks"]
+        ),
+        proximity: { longitude: -79.45, latitude: 43.65 },
+        features: [Features.QUEEN_STREET],
+        showResultsWhileTyping: false,
+        processResults,
+      });
+      geocoder.setInput("anything");
+      geocoder.on(
+        "processedResults",
+        once(function (e) {
+          t.ok(
+            e[0] === staticResults[0],
+            "processResults is overridden to return a static result"
+          );
+        })
+      );
+    }
+  );
 
   tt.end();
 });

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -637,7 +637,7 @@ test("Geocoder#addTo(HTMLElement) -- no map", function (tt) {
     container = document.createElement("div");
     container.className = "notAMap";
     document.body.appendChild(container);
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     geocoder.addTo(".notAMap");
   }
 
@@ -667,7 +667,7 @@ test("Geocoder#addTo(maplibregl.Map)", function (tt) {
     opts.enableEventLogging = false;
     container = document.createElement("div");
     var map = new maplibregl.Map({ container: container });
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     geocoder.addTo(map);
     t.ok(
       Object.keys(
@@ -684,7 +684,7 @@ test("Geocoder#addTo(maplibregl.Map)", function (tt) {
     container = document.createElement("div");
     container.className = "notAMap";
     document.body.appendChild(container);
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     geocoder.addTo(".notAMap");
     t.ok(
       Object.keys(
@@ -700,7 +700,7 @@ test("Geocoder#addTo(maplibregl.Map)", function (tt) {
     opts.enableEventLogging = false;
     container = document.createElement("div");
     document.body.appendChild(container);
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     geocoder.addTo(container);
     t.ok(
       Object.keys(
@@ -717,7 +717,7 @@ test("Geocoder#addTo(maplibregl.Map)", function (tt) {
     container = document.createElement("div");
     container.className = "notAMap";
     // we haven't added this container to the dom, we've only created it
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     t.throws(() => {
       geocoder.addTo(container);
     }, "addTo throws if the element is not found on the DOM");
@@ -733,7 +733,7 @@ test("Geocoder#addTo(maplibregl.Map)", function (tt) {
     container2.className = "notAMap";
     document.body.appendChild(container1);
     document.body.appendChild(container2);
-    geocoder = new MapboxGeocoder(opts);
+    geocoder = new MapboxGeocoder({}, opts);
     t.throws(() => {
       geocoder.addTo(".notAMap");
     }, "addTo throws if there are too many matching elements");


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
Adds
This PR brings functionality for a suggestions API. 
- Adds `getSuggestions` API function to `geocoderApi` object
  - By default, if `getSuggestions` api is available, `showResultsWhileTyping` will default to `true` and show both `geocode` and `suggestion` results
  - This was done as to not break backwards compatibility for current users of this flag for showing `geocode` results while typing.
  - For v2, it would be suggested to rethink these flags as we now have multiple types of `results`, we looked at this, but since it would have been a breaking change to rename that, we did not proceed there.
- Adds `suggestionsOnlyWhileTyping` flag - Combined with the previous, this allows the state where a developer only wants to see suggestions
- Adds `processResutls` function to the `options` object that is used to filter, sort, combine, and limit results of `forwardGeocode/reverseGeocode` and `getSuggestions`
  - Default `processResults` function:
    - Filters `suggestions` strings that are duplicated in `geocode` results, compared with geocode `feature.label`
    - Sorts `filteredSuggestions` first, followed by search results
    - Automatically divides results up to `options.limit` evenly between the two
      - if `options.limit` is an odd number, show 1 more `geocode` result than suggestion
      - if there are not enough `suggestions` or `geocode` results to fill to limit, then add more of the other until limit is reached

AutoSuggest with Geocode on typing:
![autoSuggest](https://user-images.githubusercontent.com/16496746/153265749-f7113dff-bd1d-4db3-9494-fe529f8b86f8.gif)

AutoSuggest only on typing:
![autoSuggestOnly](https://user-images.githubusercontent.com/16496746/153276359-161ac0a9-3bae-4f0c-832e-9016eb177c59.gif)

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `master` heading before merging
