### PR TITLE
Update flags to showSuggestionsWhileTyping and showResultsWhiletyping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ var subtag = require("subtag");
  * @param {Boolean} [options.localGeocoderOnly=false] If `true`, indicates that the `localGeocoder` results should be the only ones returned to the user. If `false`, indicates that the `localGeocoder` results should be combined with those from the Maplibre API with the `localGeocoder` results ranked higher.
  * @param {Boolean} [options.showResultsWhileTyping=false] If `false`, indicates that search will only occur on enter key press. If `true`, indicates that the Geocoder will search on the input box being updated above the minLength option.
  * @param {Number} [options.debounceSearch=200] Sets the amount of time, in milliseconds, to wait before querying the server when a user types into the Geocoder input box. This parameter may be useful for reducing the total number of API calls made for a single query.
- * @param {Boolean} [options.suggestionsOnlyWhileTyping=false] If `false` indicates that while typing `forwardGeocode` and `getSuggestions` API will be called and combined into the results list, if `true` only `getSuggestions` API will be called on typing.
+ * @param {Boolean} [options.showSuggestionsWhileTyping=true] If `true` suggestions api will be called on typing, if `false` it will not be called on typing..
  * @example
  *
  * var GeoApi = {
@@ -67,10 +67,6 @@ var subtag = require("subtag");
  */
 
 function MaplibreGeocoder(geocoderApi, options) {
-  if (options) {
-    options.showResultsWhileTyping =
-      !!geocoderApi.getSuggestions || options.showResultsWhileTyping;
-  }
   this._eventEmitter = new EventEmitter();
   this.options = extend({}, this.options, options);
   this.inputString = "";
@@ -203,7 +199,7 @@ MaplibreGeocoder.prototype = {
     },
     showResultMarkers: true,
     debounceSearch: 200,
-    suggestionsOnlyWhileTyping: false,
+    showSuggestionsWhileTyping: true,
   },
 
   /**
@@ -479,14 +475,11 @@ MaplibreGeocoder.prototype = {
           this._geocode(target.value);
         }
       } else {
-        // Pressing enter on the search box will do a search for the currently string input
         if (
           this._typeahead.selected == null &&
-          this.geocoderApi.getSuggestions
+          this.options.showSuggestionsWhileTyping
         ) {
-          this._geocode(target.value, true);
-
-          // If suggestions API is not defined pressing enter while the input box is selected will try to fit the results into the current map view
+          this._geocode(target.value, false);
         } else if (this._typeahead.selected == null) {
           if (this.options.showResultMarkers) {
             this._fitBoundsForMarkers();
@@ -497,14 +490,11 @@ MaplibreGeocoder.prototype = {
     }
 
     // Show results while typing and greater than min length
-    if (
-      target.value.length >= this.options.minLength &&
-      this.options.showResultsWhileTyping
-    ) {
-      // Only call getSuggestions if suggestionsOnlyWhileTyping is true
+    if (target.value.length >= this.options.minLength) {
       if (
         this.geocoderApi.getSuggestions &&
-        this.options.suggestionsOnlyWhileTyping
+        !this.options.showResultsWhileTyping &&
+        this.options.showSuggestionsWhileTyping
       ) {
         var suggestions = this._getSuggestions(target.value) || [];
         suggestions
@@ -520,10 +510,8 @@ MaplibreGeocoder.prototype = {
               this._eventEmitter.emit("error", { error: err });
             }.bind(this)
           );
-
-        // Perform search and getSuggestions while typing
-      } else {
-        this._geocode(target.value);
+      } else if (this.options.showResultsWhileTyping) {
+        this._geocode(target.value, this.options.showSuggestionsWhileTyping);
       }
     }
   },
@@ -657,7 +645,7 @@ MaplibreGeocoder.prototype = {
     return config;
   },
 
-  _geocode: function (searchInput, isSuggestion) {
+  _geocode: function (searchInput, withSuggestions) {
     this._loadingEl.style.display = "block";
     this._eventEmitter.emit("loading", { query: searchInput });
     this.inputString = searchInput;
@@ -767,7 +755,7 @@ MaplibreGeocoder.prototype = {
           }
 
           // Only getSuggestions if the API exists and the query is not from a suggestion
-          if (this.geocoderApi.getSuggestions && !isSuggestion) {
+          if (this.geocoderApi.getSuggestions && withSuggestions) {
             suggestions = this._getSuggestions(searchInput) || [];
             // supplement Geocoding API results with features returned by a promise
             return suggestions.then(
@@ -812,7 +800,7 @@ MaplibreGeocoder.prototype = {
 
             this._typeahead.update(processedResults);
             if (
-              (!this.options.showResultsWhileTyping || isSuggestion) &&
+              !this.options.showResultsWhileTyping &&
               this.options.showResultMarkers
             )
               this._fitBoundsForMarkers();

--- a/lib/index.js
+++ b/lib/index.js
@@ -477,6 +477,7 @@ MaplibreGeocoder.prototype = {
       } else {
         if (
           this._typeahead.selected == null &&
+          this.geocoderApi.getSuggestions &&
           this.options.showSuggestionsWhileTyping
         ) {
           this._geocode(target.value, false);

--- a/lib/index.js
+++ b/lib/index.js
@@ -491,28 +491,32 @@ MaplibreGeocoder.prototype = {
 
     // Show results while typing and greater than min length
     if (target.value.length >= this.options.minLength) {
-      if (
-        this.geocoderApi.getSuggestions &&
-        !this.options.showResultsWhileTyping &&
-        this.options.showSuggestionsWhileTyping
-      ) {
-        var suggestions = this._getSuggestions(target.value) || [];
-        suggestions
-          .then(
-            function (response) {
-              this._clearEl.style.display = "block";
-              this._eventEmitter.emit("resultsSuggestions", response);
-              this._typeahead.update(response);
-            }.bind(this)
-          )
-          .catch(
-            function (err) {
-              this._eventEmitter.emit("error", { error: err });
-            }.bind(this)
-          );
-      } else if (this.options.showResultsWhileTyping) {
-        this._geocode(target.value, this.options.showSuggestionsWhileTyping);
-      }
+      this._onInputChanged(target.value);
+    }
+  },
+
+  _onInputChanged: function (value) {
+    if (
+      this.geocoderApi.getSuggestions &&
+      !this.options.showResultsWhileTyping &&
+      this.options.showSuggestionsWhileTyping
+    ) {
+      var suggestions = this._getSuggestions(value) || [];
+      suggestions
+        .then(
+          function (response) {
+            this._clearEl.style.display = "block";
+            this._eventEmitter.emit("resultsSuggestions", response);
+            this._typeahead.update(response);
+          }.bind(this)
+        )
+        .catch(
+          function (err) {
+            this._eventEmitter.emit("error", { error: err });
+          }.bind(this)
+        );
+    } else if (this.options.showResultsWhileTyping) {
+      this._geocode(value, this.options.showSuggestionsWhileTyping);
     }
   },
 
@@ -1073,11 +1077,8 @@ MaplibreGeocoder.prototype = {
     this._inputEl.value = searchInput;
     this._typeahead.selected = null;
     this._typeahead.clear();
-    if (
-      searchInput.length >= this.options.minLength &&
-      this.options.showResultsWhileTyping
-    ) {
-      this._geocode(searchInput);
+    if (searchInput.length >= this.options.minLength) {
+      this._onInputChanged(searchInput);
     }
     return this;
   },


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- Updated to have two flags `showSuggestionsWhileTyping` and `showResultsWhileTyping`
- Default behavior when a suggestion API is passed in will be
  - `showSuggestionsWhileTyping` defaults true
  - `showResultsWhileTyping` defaults false
  - Enter zooms around search results
- `showSuggestionsWhileTyping` false and `showResultsWhileTyping` false
  - Enter zooms around search results, no suggestions API calls made
- `showSuggestionsWhileTyping` false and `showResultsWhileTyping` true
  - Calls search API while typing
  - Enter zooms around search results, no suggestions API calls made
- `showSuggestionsWhileTyping` true and `showResultsWhileTyping` false
  - Calls suggestions API while typing
  - Enter calls search API, zooms around search results
- `showSuggestionsWhileTyping` true and `showResultsWhileTyping` true
  - Calls suggestions and search API while typing
  - Enter calls search API ONLY with current typed out value, does not zoom around search results

Quip doc with gifs - https://quip-amazon.com/qdvRAuas7Kl0/MapLibre-Geocoder-Behaviors-v2





 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `master` heading before merging
