### PR TITLE
fix: fix bug where search cannot be done without fully clearing input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bug fixes 🐛
 
-- N/A
+- fix: fix bug where search cannot be done without fully clearing input [#72](https://github.com/maplibre/maplibre-gl-geocoder/pull/72)
 
 ## 1.3.1
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -579,11 +579,12 @@ MaplibreGeocoder.prototype = {
       }
 
       // After selecting a feature, re-focus the textarea and set
-      // cursor at start.
+      // cursor at start, and reset the selected feature.
       this._inputEl.focus();
       this._inputEl.scrollLeft = 0;
       this._inputEl.setSelectionRange(0, 0);
       this.lastSelected = JSON.stringify(selected);
+      this._typeahead.selected = null; // reset selection current selection value and set it to last selected
       this._eventEmitter.emit("result", { result: selected });
     }
   },

--- a/test/test.geocoder.js
+++ b/test/test.geocoder.js
@@ -110,6 +110,31 @@ test("geocoder", function (tt) {
     );
   });
 
+  tt.test("Selected value is reset after a result is selected", function (t) {
+    t.plan(3);
+    setup({
+      proximity: { longitude: -79.45, latitude: 43.65 },
+      features: [Features.QUEEN_STREET],
+    });
+    geocoder.query("Queen Street");
+    geocoder.on(
+      "result",
+      once(function (e) {
+        t.ok(e.result, "feature is in the event object");
+        t.notEquals(
+          geocoder.lastSelected,
+          undefined,
+          "last selected is not undefined"
+        );
+        t.equals(
+          geocoder._typeahead.selected,
+          null,
+          "selected is reset to null after setting input"
+        );
+      })
+    );
+  });
+
   tt.test("options", function (t) {
     t.plan(6);
     setup({


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

### Overview
- Bug discovered where user cannot perform a search without clearing the text box
- Fixes https://github.com/maplibre/maplibre-gl-geocoder/issues/73

 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [x] run `npm run docs` and commit changes to API.md
 - [x] update CHANGELOG.md with changes under `main` heading before merging
