### PR TITLE
fix: fix bug with fitbounds array, fix bug where clearbutton doesnt show up after pressing enter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -499,7 +499,7 @@ MaplibreGeocoder.prototype = {
   },
 
   _showButton: function () {
-    if (this._typeahead.selected) this._clearEl.style.display = "block";
+    if (this._inputEl.value.length > 0) this._clearEl.style.display = "block";
   },
 
   _hideButton: function () {
@@ -514,6 +514,10 @@ MaplibreGeocoder.prototype = {
       this._collapse();
     }
   },
+  // Change events are fire by suggestions library whenever the enter key is pressed or input is blurred
+  // This can sometimes cause strange behavior as this function is called before our own onKeyDown handler and thus
+  //  we cannot depend on some internal values of the suggestion state like `selected` as those will change or before
+  //  our onKeyDown handler.
   _onChange: function () {
     var selected = this._typeahead.selected;
 
@@ -771,7 +775,6 @@ MaplibreGeocoder.prototype = {
 
           if (res.features.length) {
             this._clearEl.style.display = "block";
-            this._eventEmitter.emit("results", res);
 
             var processedResults = this.options.processResults(
               res.features,
@@ -779,14 +782,15 @@ MaplibreGeocoder.prototype = {
               this.options.limit
             );
 
-            this._eventEmitter.emit("processedResults", processedResults);
-
             this._typeahead.update(processedResults);
             if (
               (!this.options.showResultsWhileTyping || isSuggestion) &&
               this.options.showResultMarkers
             )
               this._fitBoundsForMarkers();
+
+            this._eventEmitter.emit("results", res);
+            this._eventEmitter.emit("processedResults", processedResults);
           } else {
             this._clearEl.style.display = "none";
             this._typeahead.selected = null;
@@ -1035,7 +1039,7 @@ MaplibreGeocoder.prototype = {
           bounds.extend(feature.geometry.coordinates);
         });
 
-        this._map.fitBounds(bounds, flyOptions);
+        this._map.fitBounds(bounds.toArray(), flyOptions);
       }
     }
 

--- a/test/test.ui.js
+++ b/test/test.ui.js
@@ -343,6 +343,26 @@ test("Geocoder#inputControl", function (tt) {
     t.end();
   });
 
+  tt.test("clear button shows up", function (t) {
+    t.plan(1);
+    setup({
+      clearOnBlur: true,
+    });
+
+    geocoder.setInput("testval");
+
+    var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+    var hoverEvent = document.createEvent("Event");
+    hoverEvent.initEvent("mouseenter", true, true);
+    wrapper.dispatchEvent(hoverEvent);
+    var clearbutton = container.querySelector(
+      ".maplibregl-ctrl-geocoder--button"
+    );
+    t.equal(clearbutton.style.display, "block");
+
+    t.end();
+  });
+
   tt.test("options.collapsed=true, hover", function (t) {
     t.plan(1);
     setup({
@@ -378,8 +398,9 @@ test("Geocoder#inputControl", function (tt) {
   tt.test(
     "options.showResultsWhileTyping=false, enter key press",
     function (t) {
-      t.plan(2);
+      t.plan(4);
       setup({
+        features: [Features.QUEEN_STREET],
         collapsed: true,
         showResultsWhileTyping: false,
         maplibregl: maplibregl,
@@ -387,6 +408,7 @@ test("Geocoder#inputControl", function (tt) {
 
       var wrapper = container.querySelector(".maplibregl-ctrl-geocoder input");
       var searchMock = sinon.spy(geocoder, "_geocode");
+      var mapFitBoundsMock = sinon.spy(map, "fitBounds");
 
       geocoder.setInput("Paris");
       t.ok(
@@ -398,7 +420,13 @@ test("Geocoder#inputControl", function (tt) {
       geocoder.on(
         "results",
         once(function () {
-          t.pass("results are returned");
+          var boundsArray = mapFitBoundsMock.args[0][0];
+          t.ok(
+            mapFitBoundsMock.calledOnce,
+            "the map#fitBounds method was called when enter was pressed"
+          );
+          t.equals(boundsArray[0].length, 2, "center.lng changed");
+          t.equals(boundsArray[1].length, 2, "center.lat changed");
           t.end();
         })
       );


### PR DESCRIPTION


<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- fitBounds throws an error with certain versions of maplibre-gl typescript due to type error with LngLatBoundsLike, fixed this error by just passing in an array of bounds instead of a LngLatBoundsLike object
- After https://github.com/maplibre/maplibre-gl-geocoder/pull/72 the clearButton was not showing up because the logic was defined as only showing up if there is a `selected` target
  - Updated logic to show the clear button if there is any value in the inputElement field
  - added unit tests that verify the clear button shows up

<img width="1363" alt="Screen Shot 2022-08-08 at 5 52 58 PM" src="https://user-images.githubusercontent.com/68032955/183539366-f340ec6a-1f93-4ccc-a56b-bbb0d95b3ef1.png">


 - [x] briefly describe the changes in this PR
 - [x] write tests for all new functionality
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `main` heading before merging
