### PR TITLE
Update example usage in Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var Geo = {
 };
 
 // Pass in or define a geocoding API that matches the above
-const geocoder = new MaplibreGeocoder(Geo, { mapboxgl: maplibregl });
+const geocoder = new MaplibreGeocoder(Geo, { maplibregl: maplibregl });
 
 ```
 


### PR DESCRIPTION
In the README file, the parameter `mapboxgl` was used instead of `maplibregl` in the usage example, and this issue has been fixed in this PR.

 - [ ] briefly describe the changes in this PR
 - [ ] run `npm run docs` and commit changes to API.md
 - [ ] update CHANGELOG.md with changes under `main` heading before merging
