### PR TITLE
Make the clear button type="button"

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -289,6 +289,7 @@ MaplibreGeocoder.prototype = {
     );
 
     this._clearEl = document.createElement("button");
+    this._clearEl.setAttribute("type", "button");
     this._clearEl.setAttribute("aria-label", "Clear");
     this._clearEl.addEventListener("click", this.clear);
     this._clearEl.className =


### PR DESCRIPTION
Explicitely set the clear button to type="button" so it doesn't interfere with form submission, when the Geocoder is used inside a form.

Fixes #115
