### PR TITLE
Add code coverage, add `once`, improve test and code readability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,14 @@ jobs:
         run: |
           npm test
 
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: ${{ github.workspace }}/coverage/coverage-final.json
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+          disable_search: true
+
       - name: Docs
         run: |
           npm run docs

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -8,7 +8,6 @@ const config = tseslint.config(
       '**/dist/*',
       '**/docs/*',
       '**/coverage/*',
-      '**/test/*',
       'tsconfig.json',
     ]
   },
@@ -16,7 +15,8 @@ const config = tseslint.config(
   ...tseslint.configs.recommended,
   {
     rules: {
-      "@typescript-eslint/no-explicit-any": "off"
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
     },
   }
 );

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1513,7 +1513,7 @@ export default class MaplibreGeocoder {
    * - __error__ `{ error } Error as string`
    * @returns a Promise that resolves when the event is emitted.
    */
-  once(type: string): Promise<void> {
+  once(type: string): Promise<any> {
     return new Promise((resolve) => {
       this._eventEmitter.once(type, resolve);
     });
@@ -1524,7 +1524,7 @@ export default class MaplibreGeocoder {
    * @param type - Event name.
    * @param fn - Function that should unsubscribe to the event emitted.
    */
-  off(type: string, fn): this {
+  off(type: string, fn: (e: any) => void): this {
     this._eventEmitter.removeListener(type, fn);
     return this;
   }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -577,8 +577,9 @@ export default class MaplibreGeocoder {
   }
 
   _onKeyDown(e) {
-    const ESC_KEY_CODE = 27,
-      TAB_KEY_CODE = 9;
+    const ESC_KEY_CODE = 27;
+    const TAB_KEY_CODE = 9;
+    const ENTER_KEY_CODE = 13;
 
     if (e.keyCode === ESC_KEY_CODE && this.options.clearAndBlurOnEsc) {
       this._clear(e);
@@ -607,7 +608,7 @@ export default class MaplibreGeocoder {
       return;
 
     // ENTER
-    if (e.keyCode === 13) {
+    if (e.keyCode === ENTER_KEY_CODE) {
       if (!this.options.showResultsWhileTyping) {
         if (!this._typeahead.selected) {
           this._geocode(target.value);
@@ -1083,7 +1084,7 @@ export default class MaplibreGeocoder {
 
     // Filter out suggestions and restrict to limit
     const results = this._typeahead.data
-      .filter(function (result) {
+      .filter((result) => {
         return typeof result === "string" ? false : true;
       })
       .slice(0, this.options.limit);
@@ -1095,9 +1096,9 @@ export default class MaplibreGeocoder {
         const defaultFlyOptions = { padding: 100 };
         const flyOptions = extend({}, defaultFlyOptions, this.options.flyTo as any);
         const bounds = new this._maplibregl.LngLatBounds();
-        results.forEach(function (feature) {
+        for (const feature of results) {
           bounds.extend(feature.geometry.coordinates);
-        });
+        }
         this._map.fitBounds(bounds, flyOptions);
       }
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1026,9 +1026,8 @@ export default class MaplibreGeocoder {
    * Set & query the input
    * @param searchInput - location name or other search input
    */
-  query(searchInput: string): this {
-    this._geocode(searchInput).then(this._onQueryResult);
-    return this;
+  query(searchInput: string) {
+    return this._geocode(searchInput).then(this._onQueryResult);
   }
 
   _renderError() {

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -776,16 +776,16 @@ export default class MaplibreGeocoder {
     this._loadingEl.style.display = "block";
     this._eventEmitter.emit("loading", { query: searchInput });
 
-    let config = this._getConfigForRequest();
-    let request = this._createGeocodeRequest(config, searchInput, isSuggestion, isPlaceId);
+    const config = this._getConfigForRequest();
+    const request = this._createGeocodeRequest(config, searchInput, isSuggestion, isPlaceId);
 
-    let localGeocoderResults = this.options.localGeocoder
+    const localGeocoderResults = this.options.localGeocoder
       ? (this.options.localGeocoder(searchInput) || [])
       : [];
-    let externalGeocoderResults = [];
+    const externalGeocoderResults = [];
     
     try {
-      let response = await request;
+      const response = await request;
       await this._handleGeocodeResponse(
         response, 
         config,
@@ -874,12 +874,12 @@ export default class MaplibreGeocoder {
       ? localGeocoderResults.concat(res.features)
       : localGeocoderResults;
 
-    let externalGeocoderResultsPromise = this.options.externalGeocoder 
+    const externalGeocoderResultsPromise = this.options.externalGeocoder 
       ? (this.options.externalGeocoder(searchInput, res.features, config) || Promise.resolve([]))
       : Promise.resolve([]);
       // supplement Geocoding API results with features returned by a promise
     try {
-      let features = await externalGeocoderResultsPromise;
+      const features = await externalGeocoderResultsPromise;
       externalGeocoderResults.splice(0, 0, ...features);
       res.features = res.features
           ? features.concat(res.features)
@@ -1032,7 +1032,7 @@ export default class MaplibreGeocoder {
    * @param searchInput - location name or other search input
    */
   async query(searchInput: string) {
-    let results = await this._geocode(searchInput);
+    const results = await this._geocode(searchInput);
     this._onQueryResult(results as any);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "eslint": "^9.9.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
-        "lodash.once": "^4.0.0",
         "maplibre-gl": "^4.5.1",
         "rollup": "^4.21.0",
         "rollup-plugin-dts": "^6.1.1",
@@ -6959,12 +6958,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -14037,12 +14030,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint": "^9.9.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "lodash.once": "^4.0.0",
     "maplibre-gl": "^4.5.1",
     "rollup": "^4.21.0",
     "rollup-plugin-dts": "^6.1.1",

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -938,11 +938,10 @@ describe("geocoder", () => {
           })
         );
       });
-      /* HM TODO: Need to figure out how to test this
-      test("error is shown after an error occurred", () => {
+
+      test("error is shown after an error occurred", async () => {
         setup({ errorMessage: "A mock error message" });
         const renderMessageSpy = jest.spyOn(geocoder, "_renderMessage");
-        geocoder.query("12,");
         geocoder.on(
           "error",
           once(() => {
@@ -952,15 +951,13 @@ describe("geocoder", () => {
             expect(calledWithArgs.indexOf("There was an error reaching the server") > -1).toBeTruthy();
           })
         );
+        await expect(geocoder.query("12,")).rejects.toBe("A mock error message");
       });
-      
-    
-      test(
-        "error is shown after an error occurred [with local geocoder]",
-        () => {
+
+      test("error is shown after an error occurred [with local geocoder]", async () => {
           setup({
             errorMessage: "mock error",
-            localGeocoder: function () {
+            localGeocoder: () => {
               return [
                 {
                   type: "Feature",
@@ -973,22 +970,14 @@ describe("geocoder", () => {
               ];
             },
           });
-          var renderErrorSpy = sinon.spy(geocoder, "_renderError");
-          geocoder.query("12,");
-          geocoder.on(
-            "error",
-            once(() => {
-              t.notOk(
-                renderErrorSpy.called,
-                "the error message is not rendered when the local geocoder returns successfully"
-              );
-              
-            })
-          );
+          var renderErrorSpy = jest.spyOn(geocoder, "_renderError");
+          geocoder.on("error", once(() => {
+              expect(renderErrorSpy).not.toHaveBeenCalled();
+          }));
+          await expect(geocoder.query("12,")).rejects.toBe("mock error");
         }
       );
-      */
-    
+
       test("message is shown if no results are returned", () => {
         setup({});
         const renderMessageSpy = jest.spyOn(geocoder, "_renderNoResults");

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -210,7 +210,7 @@ describe("geocoder", () => {
           flyTo: false,
           limit: 6,
           localGeocoder: (q) => {
-            return [q];
+            return [{text: q}];
           },
         });
         geocoder.query("-30,150");
@@ -227,7 +227,7 @@ describe("geocoder", () => {
                         geocoder.on(
                             "results",
                             once((e) => {
-                                expect(e.features[0]).toBe("London");
+                                expect(e.features[0].text).toBe("London");
                                 done();
                             })
                         );

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -4,11 +4,10 @@ import Features from "./mockFeatures";
 import { createMarkerMock, createPopupMock, LngLatBoundsMock, MapMock, init, createMockGeocoderApiWithSuggestions } from "./utils";
 
 describe("geocoder", () => {
-  let container: HTMLElement, map: MapMock, geocoder: any;
+  let map: MapMock, geocoder: any;
 
   function setup(opts?: any) {
     const initResults = init(opts);
-    container = initResults.container;
     map = initResults.map;
     geocoder = initResults.geocoder;
   }
@@ -18,39 +17,30 @@ describe("geocoder", () => {
         expect(geocoder).toBeDefined();
     });
 
-    test("set/get input", () => {
-        expect.assertions(3);
+    test("set/get input", async () => {
         setup({
             proximity: { longitude: -79.45, latitude: 43.65 },
             features: [Features.QUEEN_STREET],
         });
         geocoder.query("Queen Street");
         var mapMoveSpy = jest.spyOn(map, "flyTo");
-        geocoder.on(
-            "result",
-            (e) => {
-                expect(mapMoveSpy).toHaveBeenCalledTimes(1);
-                var mapMoveArgs = mapMoveSpy.mock.calls[0][0];
-                expect(mapMoveArgs.center[0]).not.toBe(0);
-                expect(mapMoveArgs.center[1]).not.toBe(0);
-            }
-        );
+        await geocoder.once("result");
+        expect(mapMoveSpy).toHaveBeenCalledTimes(1);
+        var mapMoveArgs = mapMoveSpy.mock.calls[0][0];
+        expect(mapMoveArgs.center[0]).not.toBe(0);
+        expect(mapMoveArgs.center[1]).not.toBe(0);
     });
 
-    test("Selected value is reset after a result is selected", () => {
+    test("Selected value is reset after a result is selected", async () => {
         expect.assertions(2);
         setup({
             proximity: { longitude: -79.45, latitude: 43.65 },
             features: [Features.QUEEN_STREET],
         });
         geocoder.query("Queen Street");
-        geocoder.on(
-            "result",
-            (e) => {
-            expect(geocoder.lastSelected).toBeDefined();
-            expect(geocoder._typeahead.selected).toBeNull();
-            }
-        );
+        await geocoder.once("result");
+        expect(geocoder.lastSelected).toBeDefined();
+        expect(geocoder._typeahead.selected).toBeNull();
     });
 
     test("options", (done) => {
@@ -290,8 +280,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once((e) => {
-            expect(fitBoundsSpy).toHaveBeenCalledTimes(1);
-            var fitBoundsArgs = fitBoundsSpy.mock.calls[0][0];
+            expect(fitBoundsSpy).toHaveBeenCalledTimes(2);
+            var fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
             // flatten
             var mapBBox = [
               fitBoundsArgs[0][0],
@@ -314,8 +304,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(fitBoundsSpy).toHaveBeenCalledTimes(1);
-            var fitBoundsArgs = fitBoundsSpy.mock.calls[0][0];
+            expect(fitBoundsSpy).toHaveBeenCalledTimes(2);
+            var fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
             // flatten
             var mapBBox = [
               fitBoundsArgs[0][0],
@@ -595,8 +585,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(mapFlyMethod).toHaveBeenCalledTimes(1);
-            var calledWithArgs = mapFlyMethod.mock.calls[0][1];
+            expect(mapFlyMethod).toHaveBeenCalledTimes(2);
+            var calledWithArgs = mapFlyMethod.mock.calls[1][1];
             expect(calledWithArgs.speed).toBe(5);
           })
         );
@@ -615,8 +605,8 @@ describe("geocoder", () => {
           geocoder.on(
             "result",
             once(() => {
-                expect(mapFlyMethod).toHaveBeenCalledTimes(1);
-                var calledWithArgs = mapFlyMethod.mock.calls[0][1];
+                expect(mapFlyMethod).toHaveBeenCalledTimes(2);
+                var calledWithArgs = mapFlyMethod.mock.calls[1][1];
                 expect(calledWithArgs.speed).toBe(5);
             })
           );
@@ -636,8 +626,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(markerConstructorSpy).toHaveBeenCalledTimes(1);
-            var calledWithOptions = markerConstructorSpy.mock.calls[0][0];
+            expect(markerConstructorSpy).toHaveBeenCalledTimes(2);
+            var calledWithOptions = markerConstructorSpy.mock.calls[1][0];
             expect(calledWithOptions.color).toBe("#4668F2");
           })
         );
@@ -660,8 +650,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(markerConstructorSpy).toHaveBeenCalledTimes(1);
-            var calledWithOptions = markerConstructorSpy.mock.calls[0][0];
+            expect(markerConstructorSpy).toHaveBeenCalledTimes(2);
+            var calledWithOptions = markerConstructorSpy.mock.calls[1][0];
             expect(calledWithOptions.color).toBe("purple");
             expect(calledWithOptions.draggable).toBe(true);
             expect(calledWithOptions.anchor).toBe("top");
@@ -700,7 +690,7 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(popupConstructorSpy).toHaveBeenCalledTimes(1);
+            expect(popupConstructorSpy).toHaveBeenCalledTimes(2);
           })
         );
       });
@@ -721,8 +711,8 @@ describe("geocoder", () => {
         geocoder.on(
           "result",
           once(() => {
-            expect(popupConstructorSpy).toHaveBeenCalledTimes(1);
-            var calledWithOptions = popupConstructorSpy.mock.calls[0][0];
+            expect(popupConstructorSpy).toHaveBeenCalledTimes(2);
+            var calledWithOptions = popupConstructorSpy.mock.calls[1][0];
             expect(calledWithOptions.closeOnMove).toBe(true);
           })
         );
@@ -996,7 +986,6 @@ describe("geocoder", () => {
             localGeocoderOnly: true,
           };
           // no access token here
-          container = document.createElement("div");
           const map = new MapMock({});
           geocoder = new MaplibreGeocoder({} as any, opts);
           expect(() => map.addControl(geocoder)).toThrow();

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -1,4 +1,4 @@
-import MaplibreGeocoder from "../dist/maplibre-gl-geocoder.js";
+import MaplibreGeocoder from "../lib/index";
 import once from "lodash.once";
 import Features from "./mockFeatures";
 import { createMarkerMock, createPopupMock, LngLatBoundsMock, MapMock, init, createMockGeocoderApiWithSuggestions } from "./utils";

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -22,10 +22,10 @@ describe("geocoder", () => {
             features: [Features.QUEEN_STREET],
         });
         geocoder.query("Queen Street");
-        var mapMoveSpy = jest.spyOn(map, "flyTo");
+        const mapMoveSpy = jest.spyOn(map, "flyTo");
         await geocoder.once("result");
         expect(mapMoveSpy).toHaveBeenCalledTimes(1);
-        var mapMoveArgs = mapMoveSpy.mock.calls[0][0];
+        const mapMoveArgs = mapMoveSpy.mock.calls[0][0];
         expect(mapMoveArgs.center[0]).not.toBe(0);
         expect(mapMoveArgs.center[1]).not.toBe(0);
     });
@@ -56,14 +56,14 @@ describe("geocoder", () => {
         expect(geocoder.fresh).toBe(false);
         
         e = await geocoder.once("result")
-        var center = map.getCenter();
+        const center = map.getCenter();
         expect(center.lng).toBe(0);
         expect(center.lat).toBe(0);
         expect(e.result.place_name).toBe("Paris, France");
       });
 
       test("options.bbox", async () => {
-        var bbox = [
+        const bbox = [
           -122.71901248631752, 37.62347223479118, -122.18070124967602,
           37.87996631184369,
         ];
@@ -143,7 +143,7 @@ describe("geocoder", () => {
       test("options:zoom", async () => {
         setup({ zoom: 12, features: [Features.BELLINGHAM] });
         const q = geocoder.query("1714 14th St NW");
-        var mapMoveSpy = jest.spyOn(map, "flyTo");
+        const mapMoveSpy = jest.spyOn(map, "flyTo");
         await geocoder.once("results");
         await q;
         const mapMoveArgs = mapMoveSpy.mock.calls[0][0];
@@ -213,9 +213,9 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(fitBoundsSpy).toHaveBeenCalledTimes(2);
-        var fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
+        const fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
         // flatten
-        var mapBBox = [
+        const mapBBox = [
           fitBoundsArgs[0][0],
           fitBoundsArgs[0][1],
           fitBoundsArgs[1][0],
@@ -233,22 +233,22 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(fitBoundsSpy).toHaveBeenCalledTimes(2);
-        var fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
+        const fitBoundsArgs = fitBoundsSpy.mock.calls[1][0];
         // flatten
-        var mapBBox = [
+        const mapBBox = [
           fitBoundsArgs[0][0],
           fitBoundsArgs[0][1],
           fitBoundsArgs[1][0],
           fitBoundsArgs[1][1],
         ];
-        var expectedBBoxFlat = [-140.99778, 41.675105, -52.648099, 83.23324];
+        const expectedBBoxFlat = [-140.99778, 41.675105, -52.648099, 83.23324];
         for (let i = 0; i <  mapBBox.length; i++) {
             expect(mapBBox[i]).toBeCloseTo(expectedBBoxFlat[i]);
         }
       });
 
       test("options.filter", async () => {
-        var features = [
+        const features = [
           {
             geometry: {
               type: "Point",
@@ -326,7 +326,7 @@ describe("geocoder", () => {
       });
 
       test("options.setProximity", async () => {
-        var features = [];
+        const features = [];
         setup({ features });
     
         map.setZoom(13);
@@ -346,7 +346,7 @@ describe("geocoder", () => {
           },
         });
     
-        var fixture = {
+        const fixture = {
           id: "abc123",
           place_name: "San Francisco, California",
         };
@@ -358,14 +358,14 @@ describe("geocoder", () => {
 
       test("setRenderFunction with no input", () => {
         setup({});
-        var result = geocoder.setRenderFunction();
+        const result = geocoder.setRenderFunction();
         expect(typeof geocoder._typeahead.render).toBe("function");
         expect(result instanceof MaplibreGeocoder).toBeTruthy();
       });
 
       test("setRenderFunction with function input", () => {
         setup({});
-        var result = geocoder.setRenderFunction(function (item) {
+        const result = geocoder.setRenderFunction(function (item) {
           return item.place_name;
         });
         expect(typeof geocoder._typeahead.render).toBe("function");
@@ -374,7 +374,7 @@ describe("geocoder", () => {
 
       test("getRenderFunction default", () => {
         setup({});
-        var result = geocoder.getRenderFunction();
+        const result = geocoder.getRenderFunction();
         expect(result).toBeDefined();
         expect(typeof result).toBe("function");
       });
@@ -385,7 +385,7 @@ describe("geocoder", () => {
             return item.place_name;
           },
         });
-        var result = geocoder.getRenderFunction();
+        const result = geocoder.getRenderFunction();
         expect(result).toBeDefined();
         expect(typeof result).toBe("function");
       });
@@ -397,7 +397,7 @@ describe("geocoder", () => {
           },
         });
     
-        var fixture = {
+        const fixture = {
           id: "abc123",
           place_name: "San Francisco, California",
         };
@@ -410,7 +410,7 @@ describe("geocoder", () => {
       test("options.getItemValue default", () => {
         setup({});
     
-        var fixture = {
+        const fixture = {
           id: "abc123",
           place_name: "San Francisco, California",
         };
@@ -427,7 +427,7 @@ describe("geocoder", () => {
         });
         const mapFlyMethod = jest.spyOn(map, "flyTo");
         geocoder.query("Golden Gate Bridge");
-        const e = await geocoder.once("results");
+        await geocoder.once("results");
         expect(mapFlyMethod).not.toHaveBeenCalled();
       });
  
@@ -442,7 +442,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(mapFlyMethod).toHaveBeenCalledTimes(1);
-        var calledWithArgs = mapFlyMethod.mock.calls[0][0];
+        const calledWithArgs = mapFlyMethod.mock.calls[0][0];
         expect(calledWithArgs.center[0]).toBeCloseTo(-122.4785);
         expect(calledWithArgs.center[1]).toBeCloseTo(37.8191);
         expect(calledWithArgs.zoom).toBe(16);
@@ -462,7 +462,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(mapFlyMethod).toHaveBeenCalledTimes(1);
-        var calledWithArgs = mapFlyMethod.mock.calls[0][0];
+        const calledWithArgs = mapFlyMethod.mock.calls[0][0];
         expect(calledWithArgs.center[0]).toBeCloseTo(-122.4785);
         expect(calledWithArgs.center[1]).toBeCloseTo(37.8191);
         expect(calledWithArgs.zoom).toBe(4);
@@ -481,7 +481,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(mapFlyMethod).toHaveBeenCalledTimes(2);
-        var calledWithArgs = mapFlyMethod.mock.calls[1][1];
+        const calledWithArgs = mapFlyMethod.mock.calls[1][1];
         expect(calledWithArgs.speed).toBe(5);
       });
     
@@ -497,7 +497,7 @@ describe("geocoder", () => {
           await geocoder.once("results");
           await q;
           expect(mapFlyMethod).toHaveBeenCalledTimes(2);
-          var calledWithArgs = mapFlyMethod.mock.calls[1][1];
+          const calledWithArgs = mapFlyMethod.mock.calls[1][1];
           expect(calledWithArgs.speed).toBe(5);
         }
       );
@@ -514,7 +514,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(markerConstructorSpy).toHaveBeenCalledTimes(2);
-        var calledWithOptions = markerConstructorSpy.mock.calls[1][0];
+        const calledWithOptions = markerConstructorSpy.mock.calls[1][0];
         expect(calledWithOptions.color).toBe("#4668F2");
       });
 
@@ -534,7 +534,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(markerConstructorSpy).toHaveBeenCalledTimes(2);
-        var calledWithOptions = markerConstructorSpy.mock.calls[1][0];
+        const calledWithOptions = markerConstructorSpy.mock.calls[1][0];
         expect(calledWithOptions.color).toBe("purple");
         expect(calledWithOptions.draggable).toBe(true);
         expect(calledWithOptions.anchor).toBe("top");
@@ -582,7 +582,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         await q;
         expect(popupConstructorSpy).toHaveBeenCalledTimes(2);
-        var calledWithOptions = popupConstructorSpy.mock.calls[1][0];
+        const calledWithOptions = popupConstructorSpy.mock.calls[1][0];
         expect(calledWithOptions.closeOnMove).toBe(true);
       });
       
@@ -594,7 +594,7 @@ describe("geocoder", () => {
         });
     
         geocoder.query("Golden Gate Bridge");
-        const e = await geocoder.once("results");
+        await geocoder.once("results");
         expect(popupConstructorSpy).not.toHaveBeenCalled();
       });
        
@@ -713,7 +713,7 @@ describe("geocoder", () => {
             return false;
           },
         });
-        var filter = geocoder.getFilter();
+        const filter = geocoder.getFilter();
         expect(typeof filter).toBe("function");
         expect(["a", "b", "c"].filter(filter)).toEqual([]);
       });
@@ -724,15 +724,15 @@ describe("geocoder", () => {
             return true;
           },
         });
-        var initialFilter = geocoder.getFilter();
-        var filtered = ["a", "b", "c"].filter(initialFilter);
+        const initialFilter = geocoder.getFilter();
+        const filtered = ["a", "b", "c"].filter(initialFilter);
         expect(typeof initialFilter).toBe("function");
         expect(filtered).toEqual(["a", "b", "c"]);
         geocoder.setFilter(() => {
           return false;
         });
-        var nextFilter = geocoder.options.filter;
-        var nextFiltered = ["a", "b", "c"].filter(nextFilter);
+        const nextFilter = geocoder.options.filter;
+        const nextFiltered = ["a", "b", "c"].filter(nextFilter);
         expect(typeof nextFilter).toBe("function");
         expect(nextFiltered).toEqual([]);
       });
@@ -750,7 +750,7 @@ describe("geocoder", () => {
         expect(geocoder._typeahead.data.length).toBe(0);
         expect(geocoder._typeahead.selected).toBeNull();
         expect(typeaheadRenderErrorSpy).toHaveBeenCalledTimes(1);
-        var calledWithArgs = typeaheadRenderErrorSpy.mock.calls[0][0];
+        const calledWithArgs = typeaheadRenderErrorSpy.mock.calls[0][0];
         expect(calledWithArgs).toBe("<h1>This is a test</h1>");
       });
       
@@ -762,7 +762,7 @@ describe("geocoder", () => {
         await geocoder.once("results");
         geocoder._renderError();
         expect(renderMessageSpy).toHaveBeenCalledTimes(1);
-        var calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
+        const calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
         expect(calledWithArgs.indexOf("maplibre-gl-geocoder--error") > -1).toBeTruthy();
       });
       
@@ -771,10 +771,10 @@ describe("geocoder", () => {
         const renderMessageSpy = jest.spyOn(geocoder, "_renderMessage");
     
         geocoder.query("Golden Gate Bridge");
-        const e = await geocoder.once("results");
+        await geocoder.once("results");
         geocoder._renderNoResults();
         expect(renderMessageSpy).toHaveBeenCalledTimes(1);
-        var calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
+        const calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
         expect(calledWithArgs.indexOf("maplibre-gl-geocoder--error") > -1).toBeTruthy();
         expect(calledWithArgs.indexOf("maplibre-gl-geocoder--no-results") > -1).toBeTruthy();
       });
@@ -785,7 +785,7 @@ describe("geocoder", () => {
         const q = geocoder.query("12,");
         await geocoder.once("error");
         expect(renderMessageSpy).toHaveBeenCalledTimes(1);
-        var calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
+        const calledWithArgs = renderMessageSpy.mock.calls[0][0] as any;
         expect(calledWithArgs.indexOf("maplibre-gl-geocoder--error") > -1).toBeTruthy();
         expect(calledWithArgs.indexOf("There was an error reaching the server") > -1).toBeTruthy();
         await expect(q).rejects.toBe("A mock error message");
@@ -807,7 +807,7 @@ describe("geocoder", () => {
               ];
             },
           });
-          var renderErrorSpy = jest.spyOn(geocoder, "_renderError");
+          const renderErrorSpy = jest.spyOn(geocoder, "_renderError");
           const q = geocoder.query("12,");
           await geocoder.once("error");
           expect(renderErrorSpy).not.toHaveBeenCalled();
@@ -825,7 +825,7 @@ describe("geocoder", () => {
       
     
       test("throws an error if localGeocoderOnly mode is active but no localGeocoder is supplied", () => {
-          var opts = {
+          const opts = {
             localGeocoderOnly: true,
           };
           // no access token here
@@ -847,7 +847,7 @@ describe("geocoder", () => {
           showResultsWhileTyping: true,
         });
         const searchMock = jest.spyOn(geocoder, "_geocode");
-        var event = {
+        const event = {
             clipboardData: {
                 getData: () => "Golden Gate Bridge",
             },
@@ -863,7 +863,7 @@ describe("geocoder", () => {
         minLength: 5,
         });
         const searchMock = jest.spyOn(geocoder, "_geocode");
-        var event = {
+        const event = {
             clipboardData: {
                 getData: () => "abc",
             },
@@ -875,7 +875,7 @@ describe("geocoder", () => {
       test("geocoder#onPaste not triggered when there is no text", () => {
         setup();
         const searchMock = jest.spyOn(geocoder, "_geocode");
-        var event = {
+        const event = {
             clipboardData: {
                 getData: () => "",
             },

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -43,7 +43,7 @@ describe("geocoder", () => {
         expect(geocoder._typeahead.selected).toBeNull();
     });
 
-    test("options", (done) => {
+    test("options", async () => {
         setup({
           flyTo: false,
           country: "fr",
@@ -53,28 +53,18 @@ describe("geocoder", () => {
     
         geocoder.query("Paris");
     
-        geocoder.on(
-          "results",
-          once((e) => {
-            expect(e.features.length).toBe(1);
-            expect(geocoder.fresh).toBe(false);
-          }
-        ));
-    
-        geocoder.on(
-          "result",
-          once((e) => {
-            var center = map.getCenter();
-            expect(center.lng).toBe(0);
-            expect(center.lat).toBe(0);
-            expect(e.result.place_name).toBe("Paris, France");
-            done();
-          })
-        );
+        let e = await geocoder.once("results");
+        expect(e.features.length).toBe(1);
+        expect(geocoder.fresh).toBe(false);
+        
+        e = await geocoder.once("result")
+        var center = map.getCenter();
+        expect(center.lng).toBe(0);
+        expect(center.lat).toBe(0);
+        expect(e.result.place_name).toBe("Paris, France");
       });
 
-      test("options.bbox", () => {
-        expect.assertions(3);
+      test("options.bbox", async () => {
         var bbox = [
           -122.71901248631752, 37.62347223479118, -122.18070124967602,
           37.87996631184369,
@@ -85,32 +75,24 @@ describe("geocoder", () => {
         });
     
         geocoder.query("London");
-        geocoder.on(
-          "results",
-          once((e) => {
-            expect(e.features.length).toBe(1);
-            expect(e.config.bbox).toBe(bbox);
-            expect(e.features[0].text).toBe("London, Greater London, England, GBR");
-          })
-        );
+        const e = await geocoder.once("results")
+        expect(e.features.length).toBe(1);
+        expect(e.config.bbox).toBe(bbox);
+        expect(e.features[0].text).toBe("London, Greater London, England, GBR");
       });
 
-      test("options.reverseGeocode - true", () => {
+      test("options.reverseGeocode - true", async () => {
         expect.assertions(4);
         setup({
           reverseGeocode: true,
           features: [Features.TANZANIA],
         });
         geocoder.query("-6.1933875, 34.5177548");
-        geocoder.on(
-          "results",
-          once((e) => {
-            expect(e.features.length).toBe(1);
-            expect(e.features[0].place_name.indexOf("Tanzania")).toBeGreaterThan(-1);
-            expect(e.features[0].place_name.indexOf("Singida")).toBeGreaterThan(-1);
-            expect(e.config.limit).toBe(1);
-          })
-        );
+        const e = await geocoder.once("results");
+        expect(e.features.length).toBe(1);
+        expect(e.features[0].place_name.indexOf("Tanzania")).toBeGreaterThan(-1);
+        expect(e.features[0].place_name.indexOf("Singida")).toBeGreaterThan(-1);
+        expect(e.config.limit).toBe(1);
       });
 
       test("options.reverseGeocode - false by default", () => {

--- a/test/geocoder.ui.spec.ts
+++ b/test/geocoder.ui.spec.ts
@@ -3,8 +3,7 @@ import { init, initHtmlElement, initNoMap, mockGeocoderApi } from "./utils";
 import once from "lodash.once";
 
 describe("Geocoder#inputControl", () => {
-    let container, map, geocoder, geocoderApi;  
-    var changeEvent = new Event('change', {bubbles: true, cancelable: false});
+    let container, map, geocoder;  
     var clickEvent = new Event('click', {bubbles: true, cancelable: false});
   
     function setup(opts?: any) {
@@ -48,15 +47,14 @@ describe("Geocoder#inputControl", () => {
         "clear",
         once(() => {
           setTimeout(() => {
-            expect(geocoder.fresh).toBeFalsy();
+            expect(geocoder.fresh).toBeTruthy();
             expect(geocoder.mapMarker).toBeNull();
             geocoder.setInput("Paris");
             expect(inputEl.value).toBe("Paris");
-  
             geocoder.setInput("90,45");
             expect(inputEl.value).toBe("90,45");
             done();
-          });
+          }, 0);
         })
       );
   
@@ -409,7 +407,7 @@ describe("Geocoder#inputControl", () => {
         "clear",
         once(() => {
           setTimeout(() => {
-            expect(geocoder.fresh).toBeFalsy();
+            expect(geocoder.fresh).toBeTruthy();
             geocoder.setInput("Paris");
             expect(inputEl.value).toBe("Paris")
             geocoder.setInput("90,45");

--- a/test/geocoder.ui.spec.ts
+++ b/test/geocoder.ui.spec.ts
@@ -4,7 +4,7 @@ import once from "lodash.once";
 
 describe("Geocoder#inputControl", () => {
     let container, map, geocoder;  
-    var clickEvent = new Event('click', {bubbles: true, cancelable: false});
+    const clickEvent = new Event('click', {bubbles: true, cancelable: false});
   
     function setup(opts?: any) {
         const initResults = init(opts);
@@ -24,8 +24,8 @@ describe("Geocoder#inputControl", () => {
         types: "place",
         features: [Features.GOLDEN_GATE_BRIDGE],
       });
-      var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
-      var clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
+      const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+      const clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
   
       geocoder.on(
         "loading",
@@ -90,7 +90,7 @@ describe("Geocoder#inputControl", () => {
   
     test("clear is not called on keydown (tab), no focus trap", () => {
         setup({});
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         const focusSpy = jest.spyOn(inputEl, "focus");
         inputEl.focus();
         expect(focusSpy).toHaveBeenCalled();
@@ -104,7 +104,7 @@ describe("Geocoder#inputControl", () => {
     test("clear is called on keydown (not tab)", () => {
         setup({});
   
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         const focusSpy = jest.spyOn(inputEl, "focus");
         inputEl.focus();
         expect(focusSpy).toHaveBeenCalled();
@@ -119,7 +119,7 @@ describe("Geocoder#inputControl", () => {
         setup({
           clearAndBlurOnEsc: true,
         });
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         const focusSpy = jest.spyOn(inputEl, "focus");
         const blurSpy = jest.spyOn(inputEl, "blur");
   
@@ -142,7 +142,7 @@ describe("Geocoder#inputControl", () => {
         setup({
           clearAndBlurOnEsc: false,
         });
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         const focusSpy = jest.spyOn(inputEl, "focus");
         const blurSpy = jest.spyOn(inputEl, "blur");
   
@@ -160,7 +160,7 @@ describe("Geocoder#inputControl", () => {
         setup({
             collapsed: true,
         });
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
         expect(wrapper.classList.contains("maplibregl-ctrl-geocoder--collapsed")).toBeTruthy();
     });
     
@@ -168,10 +168,10 @@ describe("Geocoder#inputControl", () => {
         setup({
             collapsed: true,
         });
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         // focus input, remove maplibregl-ctrl-geocoder--collapsed
-        var focusEvent = new Event("focus", { bubbles: true, cancelable: false });
+        const focusEvent = new Event("focus", { bubbles: true, cancelable: false });
         inputEl.dispatchEvent(focusEvent);
         expect(wrapper.classList.contains("maplibregl-ctrl-geocoder--collapsed")).toBeFalsy();
     });
@@ -186,8 +186,8 @@ describe("Geocoder#inputControl", () => {
         });
         expect(geocoder.options.clearOnBlur).toBeTruthy();
   
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
-        var focusSpy = jest.spyOn(inputEl, "focus");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const focusSpy = jest.spyOn(inputEl, "focus");
   
         geocoder.setInput("testval");
         expect(inputEl.value).toBe("testval");
@@ -228,10 +228,10 @@ describe("Geocoder#inputControl", () => {
     
         geocoder.setInput("testval");
     
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
         const hoverEvent = new Event("mouseenter", { bubbles: true, cancelable: true });
         wrapper.dispatchEvent(hoverEvent);
-        var clearbutton = container.querySelector(
+        const clearbutton = container.querySelector(
             ".maplibregl-ctrl-geocoder--button"
         );
         expect(clearbutton.style.display).toBe("block");
@@ -242,7 +242,7 @@ describe("Geocoder#inputControl", () => {
         setup({
             collapsed: true,
         });
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
         // hover input, remove maplibregl-ctrl-geocoder--collapsed
         const hoverEvent = new Event("mouseenter", { bubbles: true, cancelable: true });
         wrapper.dispatchEvent(hoverEvent);
@@ -253,7 +253,7 @@ describe("Geocoder#inputControl", () => {
         setup({
             collapsed: false,
         });
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder");
         expect(wrapper.classList.contains("maplibregl-ctrl-geocoder--collapsed")).toBeFalsy();
     });
   
@@ -266,9 +266,9 @@ describe("Geocoder#inputControl", () => {
           showResultsWhileTyping: false,
         });
   
-        var wrapper = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const wrapper = container.querySelector(".maplibregl-ctrl-geocoder input");
         const searchMock = jest.spyOn(geocoder, "_geocode");
-        var mapFitBoundsMock = jest.spyOn(map, "fitBounds");
+        const mapFitBoundsMock = jest.spyOn(map, "fitBounds");
   
         geocoder.setInput("Paris");
         expect(searchMock).not.toHaveBeenCalled();
@@ -277,7 +277,7 @@ describe("Geocoder#inputControl", () => {
         geocoder.on(
           "results",
           once(() => {
-            var boundsArray = mapFitBoundsMock.mock.calls[0][0];
+            const boundsArray = mapFitBoundsMock.mock.calls[0][0];
             expect(mapFitBoundsMock).toHaveBeenCalled();
             expect(boundsArray[0].length).toBe(2);
             expect(boundsArray[1].length).toBe(2);
@@ -301,7 +301,7 @@ describe("Geocoder#inputControl", () => {
   
     test("createIcon", () => {
       setup({});
-      var icon = geocoder.createIcon("search", "<path/>");
+      const icon = geocoder.createIcon("search", "<path/>");
       expect(icon.outerHTML).toBe(
         '<svg class="maplibregl-ctrl-geocoder--icon maplibregl-ctrl-geocoder--icon-search" viewBox="0 0 18 18" xml:space="preserve" width="18" height="18"><path></path></svg>'
       );
@@ -312,9 +312,9 @@ describe("Geocoder#inputControl", () => {
         features: [Features.GOLDEN_GATE_BRIDGE],
         types: "place",
       });
-      var clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
+      const clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
   
-      var checkVal = null;
+      let checkVal = null;
   
       geocoder.on("result", once(() => {
         expect(typeof geocoder.lastSelected).toBe("string");
@@ -325,7 +325,7 @@ describe("Geocoder#inputControl", () => {
       }));
       geocoder.query("Golden Gate Bridge");
   
-      var newMock = mockGeocoderApi([Features.CANADA]);
+      const newMock = mockGeocoderApi([Features.CANADA]);
       geocoder.setGeocoderApi(newMock);
       geocoder.query("Canada");
     });
@@ -335,12 +335,12 @@ describe("Geocoder#inputControl", () => {
         types: "place",
         features: [Features.GOLDEN_GATE_BRIDGE],
       });
-      var clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
+      const clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
   
-      var lastID = "test.abc123";
+      const lastID = "test.abc123";
   
       geocoder.on("result", once(() => {
-        var selected = JSON.parse(geocoder.lastSelected);
+        const selected = JSON.parse(geocoder.lastSelected);
         selected.id = lastID;
         clearEl.dispatchEvent(clickEvent);
         done();
@@ -357,7 +357,7 @@ describe("Geocoder#inputControl", () => {
         pasteEvent.clipboardData = {
           getData () { return 'Golden Gate Bridge' }
         }
-        var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+        const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
         inputEl.dispatchEvent(pasteEvent);
     
         geocoder.on("results",
@@ -385,8 +385,8 @@ describe("Geocoder#inputControl", () => {
         types: "place",
         features: [Features.GOLDEN_GATE_BRIDGE],
       });
-      var inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
-      var clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
+      const inputEl = container.querySelector(".maplibregl-ctrl-geocoder input");
+      const clearEl = container.querySelector(".maplibregl-ctrl-geocoder button");
   
       geocoder.on(
         "loading",

--- a/test/mockFeatures.ts
+++ b/test/mockFeatures.ts
@@ -1,4 +1,4 @@
-var GOLDEN_GATE_BRIDGE = {
+const GOLDEN_GATE_BRIDGE = {
   geometry: {
     type: "Point",
     coordinates: [-122.47846999999996, 37.81914000000006],
@@ -20,7 +20,7 @@ var GOLDEN_GATE_BRIDGE = {
   center: [-122.47846999999996, 37.81914000000006],
 };
 
-var CANADA = {
+const CANADA = {
   geometry: {
     type: "Point",
     coordinates: [-113.64257999999995, 60.108670000000075],
@@ -37,7 +37,7 @@ var CANADA = {
   bbox: [-140.99778, 41.6751050889, -52.6480987209, 83.23324],
 };
 
-var QUEEN_STREET = {
+const QUEEN_STREET = {
   geometry: {
     type: "Point",
     coordinates: [0.41218404200003533, 51.18466021800003],
@@ -57,7 +57,7 @@ var QUEEN_STREET = {
   center: [0.41218404200003533, 51.18466021800003],
 };
 
-var PARIS = {
+const PARIS = {
   geometry: {
     type: "Point",
     coordinates: [2.3414000000000215, 48.85717000000005],
@@ -76,7 +76,7 @@ var PARIS = {
   center: [2.3414000000000215, 48.85717000000005],
 };
 
-var LONDON = {
+const LONDON = {
   geometry: {
     type: "Point",
     coordinates: [-0.12769869299995662, 51.507408360000056],
@@ -95,7 +95,7 @@ var LONDON = {
   center: [-0.12769869299995662, 51.507408360000056],
 };
 
-var TANZANIA = {
+const TANZANIA = {
   geometry: {
     type: "Point",
     coordinates: [34.517755, -6.193388],
@@ -114,7 +114,7 @@ var TANZANIA = {
   center: [34.517755, -6.193388],
 };
 
-var BELLINGHAM = {
+const BELLINGHAM = {
   geometry: {
     type: "Point",
     coordinates: [-122.49998672488617, 48.717186690468154],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -111,13 +111,13 @@ export function mockGeocoderApi(features, errorMessage?: string): MaplibreGeocod
         forwardGeocode: async () => {
         return new Promise(async (resolve, reject) => {
             if (errorMessage) reject(errorMessage);
-            resolve({ features: features || [] });
+            resolve({ features: features || [] } as any);
         });
         },
         reverseGeocode: async () => {
         return new Promise(async (resolve, reject) => {
             if (errorMessage) reject(errorMessage);
-            resolve({ features: features || [] });
+            resolve({ features: features || [] } as any);
         });
         },
     };

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import MaplibreGeocoder, { type MaplibreGeocoderApi } from "../dist/maplibre-gl-geocoder.js";
+import MaplibreGeocoder, { type MaplibreGeocoderApi } from "../lib/index";
 import type { FitBoundsOptions, FlyToOptions, LngLatBoundsLike } from "maplibre-gl";
 
 export class LngLatMock {
@@ -126,28 +126,28 @@ export function mockGeocoderApi(features, errorMessage?: string): MaplibreGeocod
 export function createMockGeocoderApiWithSuggestions(features, suggestions, errorMessage?: string): MaplibreGeocoderApi {
     return {
         forwardGeocode: () => {
-        return new Promise((resolve, reject) => {
-            if (errorMessage) reject(errorMessage);
-            resolve({ features: (features || []) });
-        });
+            return new Promise((resolve, reject) => {
+                if (errorMessage) reject(errorMessage);
+                resolve({ features: (features || []) });
+            });
         },
         reverseGeocode: () => {
-        return new Promise((resolve, reject) => {
-            if (errorMessage) reject(errorMessage);
-            resolve({ features: (features || []) });
-        });
+            return new Promise((resolve, reject) => {
+                if (errorMessage) reject(errorMessage);
+                resolve({ features: (features || []) });
+            });
         },
         getSuggestions: () => {
-        return new Promise((resolve, reject) => {
-            if (errorMessage) reject(errorMessage);
-            resolve({ suggestions: suggestions || [], features: [] });
-        });
+            return new Promise((resolve, reject) => {
+                if (errorMessage) reject(errorMessage);
+                resolve({ suggestions: suggestions || [], features: [] });
+            });
         },
         searchByPlaceId: () => {
-        return new Promise((resolve, reject) => {
-            if (errorMessage) reject(errorMessage);
-            resolve({ features: features[0] || [] });
-        });
+            return new Promise((resolve, reject) => {
+                if (errorMessage) reject(errorMessage);
+                resolve({ features: features[0] || [] });
+            });
         },
     } as any;
 }

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -18,10 +18,10 @@ export class MapMock {
     addControl(c) { this.container.appendChild(c.onAdd(this))};
     removeControl(c) {c.onRemove(this)};
     getZoom() {return this.zoom};
-    on(type: string, cb: Function) { this.cbMap[type] = cb; };
-    off(type: string, cb: Function) { delete this.cbMap[type]; }
-    flyTo(opts: FlyToOptions) {};
-    fitBounds(bounds: LngLatBoundsLike, options?: FitBoundsOptions) {};
+    on(type: string, cb: (e: any) => void) { this.cbMap[type] = cb; };
+    off(type: string, _cb: (e: any) => void) { delete this.cbMap[type]; }
+    flyTo(_opts: FlyToOptions) {};
+    fitBounds(_bounds: LngLatBoundsLike, _options?: FitBoundsOptions) {};
     getCenter() {return this.center};
     jumpTo(options: { zoom: number; center: number[]; }) {
         this.center = new LngLatMock(options.center[0], options.center[1]);
@@ -40,7 +40,7 @@ export class MapMock {
 export function createMarkerMock() {
     const markerWithSpy = jest.fn();
     markerWithSpy.mockImplementation(() => {
-        let obj = {
+        const obj = {
             setLngLat: () => { return obj; },
             addTo: () => { return obj; },
             remove: () => {},
@@ -54,7 +54,7 @@ export function createMarkerMock() {
 export function createPopupMock() {
     const popupWithSpy = jest.fn();
     popupWithSpy.mockImplementation(() => {
-        let obj = {
+        const obj = {
             setHTML: () => { return obj; },
         }
         return obj;
@@ -71,12 +71,12 @@ export function init(opts?: any) {
     opts = opts || {};
     opts.enableEventLogging = false;
     opts.maplibregl = opts.maplibregl || { Marker: createMarkerMock(), LngLatBounds: LngLatBoundsMock };
-    let container = document.createElement("div");
-    let map = new MapMock({ container: container });
-    let geocoderApi =
+    const container = document.createElement("div");
+    const map = new MapMock({ container: container });
+    const geocoderApi =
       opts.geocoderApi ||
       mockGeocoderApi(opts.features, opts.errorMessage);
-    let geocoder = new MaplibreGeocoder(geocoderApi, opts);
+    const geocoder = new MaplibreGeocoder(geocoderApi, opts);
     map.addControl(geocoder);
     return { map, geocoder, container };
 }
@@ -84,11 +84,11 @@ export function init(opts?: any) {
 export function initNoMap(opts) {
     opts = opts || {};
     opts.enableEventLogging = false;
-    let container = document.createElement("div");
+    const container = document.createElement("div");
     container.className = "notAMap";
     document.body.appendChild(container);
-    let geocoderApi = mockGeocoderApi(opts.features, opts.errorMessage);
-    let geocoder = new MaplibreGeocoder(geocoderApi, opts);
+    const geocoderApi = mockGeocoderApi(opts.features, opts.errorMessage);
+    const geocoder = new MaplibreGeocoder(geocoderApi, opts);
     geocoder.addTo(".notAMap");
     return {geocoder, container}
 }
@@ -96,11 +96,11 @@ export function initNoMap(opts) {
 export function initHtmlElement(opts?: any) {
     opts = opts || {};
     opts.enableEventLogging = false;
-    let container = document.createElement("div");
+    const container = document.createElement("div");
     container.className = "notAMap";
     document.body.appendChild(container);
-    let geocoderApi = mockGeocoderApi(opts.features, opts.errorMessage);
-    let geocoder = new MaplibreGeocoder(geocoderApi, opts);
+    const geocoderApi = mockGeocoderApi(opts.features, opts.errorMessage);
+    const geocoder = new MaplibreGeocoder(geocoderApi, opts);
     geocoder.addTo(container);
     return {geocoder, container}
 }
@@ -109,13 +109,13 @@ export function initHtmlElement(opts?: any) {
 export function mockGeocoderApi(features, errorMessage?: string): MaplibreGeocoderApi {
     return {
         forwardGeocode: async () => {
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (errorMessage) reject(errorMessage);
             resolve({ features: features || [] } as any);
         });
         },
         reverseGeocode: async () => {
-        return new Promise(async (resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (errorMessage) reject(errorMessage);
             resolve({ features: features || [] } as any);
         });


### PR DESCRIPTION
I've finished updating the code to be readable, especilly the `geocode` method which was extremenly long and I had a lot of issues reading and understanding it.
I've added `once` to the public API to be able to get promises for events.
I've refactored the tests to use `async` instead of `done` and not use `lodash.once`.
I've removed the `lodash.once` package.
I've added code coverage to the CI.

