### PR TITLE
Added proximity min zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Features / Improvements 🚀
 
+- Add option to set proximity min zoom by @HarelM in https://github.com/maplibre/maplibre-gl-geocoder/pull/130
+- Add `once` event registration capability by @HarelM in https://github.com/maplibre/maplibre-gl-geocoder/pull/127
+
 ### Bug fixes 🐛
 
 ## 1.6.0

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -160,6 +160,11 @@ export type MaplibreGeocoderOptions = {
    */
   reverseMode?: "distance" | "score"
   /**
+   * If setting promiximity, this is the minimum zoom level at which to start taking it into account.
+   * @default 9
+   */
+  proximityMinZoom?: number;
+  /**
    * A function that specifies how the selected result should be rendered in the search bar. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
    * @example
    *
@@ -272,6 +277,7 @@ export default class MaplibreGeocoder {
     collapsed: false,
     clearAndBlurOnEsc: false,
     clearOnBlur: false,
+    proximityMinZoom: 9,
 
     getItemValue: (item) => {
       return item.text !== undefined ? item.text : item.place_name;
@@ -1024,7 +1030,7 @@ export default class MaplibreGeocoder {
     if (!this._map) {
       return;
     }
-    if (this._map.getZoom() > 9) {
+    if (this._map.getZoom() > this.options.proximityMinZoom) {
       const center = this._map.getCenter().wrap();
       this.setProximity({ longitude: center.lng, latitude: center.lat });
     } else {

--- a/test/geocoder.spec.ts
+++ b/test/geocoder.spec.ts
@@ -339,6 +339,24 @@ describe("geocoder", () => {
         expect(e.config.proximity[1]).toBe(43.6568);
       });
 
+      test("set proximity to null for world zoom level", async () => {
+        setup({});
+    
+        geocoder.setProximity({ longitude: 10, latitude: 11 });
+
+        map.setZoom(5);
+        expect(geocoder.getProximity()).toBeNull();
+      });
+
+      test("set proximity to null for world zoom level", async () => {
+        setup({proximityMinZoom: 4});
+    
+        geocoder.setProximity({ longitude: 10, latitude: 11 });
+
+        map.setZoom(5);
+        expect(geocoder.getProximity()).not.toBeNull();
+      });
+
       test("options.render", () => {
         setup({
           render: (feature) => {


### PR DESCRIPTION
Resolves #16.
This adds a configuration for the minimal zoom for proximity called:
`proximityMinZoom` and has the defualt of 9 so this won't break existing behavior.

- #16
