### PR TITLE
fix(build): remove type: module from package.json to fix cjs dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "module": "dist/maplibre-gl-geocoder.mjs",
   "typings": "dist/maplibre-gl-geocoder.d.ts",
   "style": "dist/maplibre-gl-geocoder.css",
-  "type": "module",
   "scripts": {
     "watch": "rollup --configPlugin @rollup/plugin-typescript -c --watch",
     "build": "rollup --configPlugin @rollup/plugin-typescript -c",


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->
- https://github.com/maplibre/maplibre-gl-geocoder/issues/132
- Tested locally by publishing to verdaccio with the `type: module` omitted and no longer see the error

 - [x] briefly describe the changes in this PR
 - [ ] write tests for all new functionality
 - [ ] update CHANGELOG.md with changes under `main` heading before merging
