### PR TITLE
Fix `MaplibreGeocoderPlaceResults` type definition

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -375,8 +375,6 @@ export default class MaplibreGeocoder {
    * const GeoApi = {
    *   forwardGeocode: (config) => { return { features: [] } },
    *   reverseGeocode: (config) => { return { features: [] } }
-   *   getSuggestions: (config) => { return { suggestions: {text: string, placeId?: string}[] }}
-   *   searchByPlaceId: (config) => { return { place: {type: string, geometry: {type: string, coordinates: [number]} place_name: string, text: string, center: [number] } }}
    * }
    * const geocoder = new MaplibreGeocoder(GeoAPI, {});
    * geocoder.addTo('#geocoder-container');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -166,16 +166,6 @@ export type MaplibreGeocoderOptions = {
   proximityMinZoom?: number;
   /**
    * A function that specifies how the selected result should be rendered in the search bar. HTML tags in the output string will not be rendered. Defaults to `(item) => item.place_name`.
-   * @example
-   *
-   * const GeoApi = {
-   *   forwardGeocode: (config) => { return { features: [] } },
-   *   reverseGeocode: (config) => { return { features: [] } }
-   *   getSuggestions: (config) => { return { suggestions: {text: string, placeId?: string}[] }}
-   *   searchByPlaceId: (config) => { return { place: {type: string, geometry: {type: string, coordinates: [number]} place_name: string, text: string, center: [number] }[] }}
-   * }
-   * const geocoder = new MaplibreGeocoder(GeoApi, {});
-   * map.addControl(geocoder);
    */
   getItemValue?: (item: CarmenGeojsonFeature) => string;
   /**
@@ -255,6 +245,7 @@ export type MaplibreGeocoderApi = {
   reverseGeocode: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderFeatureResults>;
   getSuggestions?: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderSuggestionResults>;
   searchByPlaceId?: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderPlaceResults>;
+
 };
 
 /**
@@ -384,6 +375,8 @@ export default class MaplibreGeocoder {
    * const GeoApi = {
    *   forwardGeocode: (config) => { return { features: [] } },
    *   reverseGeocode: (config) => { return { features: [] } }
+   *   getSuggestions: (config) => { return { suggestions: {text: string, placeId?: string}[] }}
+   *   searchByPlaceId: (config) => { return { place: {type: string, geometry: {type: string, coordinates: [number]} place_name: string, text: string, center: [number] } }}
    * }
    * const geocoder = new MaplibreGeocoder(GeoAPI, {});
    * geocoder.addTo('#geocoder-container');

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -227,7 +227,7 @@ export type MaplibreGeocoderApiConfig = {
 
 export type MaplibreGeocoderFeatureResults = { type: "FeatureCollection", features: CarmenGeojsonFeature[]};
 export type MaplibreGeocoderSuggestionResults = { suggestions: { text: string, placeId?: string }[] };
-export type MaplibreGeocoderPlaceResults = { place: CarmenGeojsonFeature };
+export type MaplibreGeocoderPlaceResults = { place: CarmenGeojsonFeature }[];
 export type MaplibreGeocoderResults = MaplibreGeocoderFeatureResults | MaplibreGeocoderSuggestionResults | MaplibreGeocoderPlaceResults;
 
 /**
@@ -907,7 +907,7 @@ export default class MaplibreGeocoder {
     if ('suggestions' in res) {
       results = res.suggestions;
     } else if ('place' in res) {
-      results = [res.place];
+      results = res.place;
     } else {
       results = res.features;
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -237,7 +237,7 @@ export type MaplibreGeocoderApiConfig = {
 
 export type MaplibreGeocoderFeatureResults = { type: "FeatureCollection", features: CarmenGeojsonFeature[]};
 export type MaplibreGeocoderSuggestionResults = { suggestions: { text: string, placeId?: string }[] };
-export type MaplibreGeocoderPlaceResults = { place: CarmenGeojsonFeature[] };
+export type MaplibreGeocoderPlaceResults = { place: CarmenGeojsonFeature };
 export type MaplibreGeocoderResults = MaplibreGeocoderFeatureResults | MaplibreGeocoderSuggestionResults | MaplibreGeocoderPlaceResults;
 
 /**


### PR DESCRIPTION
Fix `MaplibreGeocoderPlaceResults` type definition and update documentation in code to reflect expected return of `searchByPlaceId` function. Fixes #162

<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [X] briefly describe the changes in this PR

