### PR TITLE
make reverseGeocode optional in MaplibreGeocoderApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features / Improvements 🚀
 
 - Migrate unit tests to Vitest https://github.com/maplibre/maplibre-gl-geocoder/pull/238
+- Make the `reverseGeocode` field in `MaplibreGeocoderAPI` optional https://github.com/maplibre/maplibre-gl-geocoder/pull/245
 
 ### Bug fixes 🐛
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -252,7 +252,7 @@ export type MaplibreGeocoderApi = {
   /**
    * Reverse geocode function should return an object including a collection of {@link CarmenGeojsonFeature}.
    */
-  reverseGeocode: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderFeatureResults>;
+  reverseGeocode?: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderFeatureResults>;
   getSuggestions?: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderSuggestionResults>;
   searchByPlaceId?: (config: MaplibreGeocoderApiConfig) => Promise<MaplibreGeocoderPlaceResults>;
 };


### PR DESCRIPTION
title says it all

fixes https://github.com/maplibre/maplibre-gl-geocoder/issues/173 (although that is already closed as the author found and used a workaround)

 - [x] briefly describe the changes in this PR
 - [x] update CHANGELOG.md with changes under `main` heading before merging
