### PR TITLE
Add navigation links to TypeDoc header

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+    "navigationLinks": {
+      "Example": "https://maplibre.org/maplibre-gl-js/docs/examples/geocoder/",
+      "GitHub": "https://github.com/maplibre/maplibre-gl-geocoder"
+  },
+}


### PR DESCRIPTION
Add navigation links to TypeDoc header.

<img width="333" alt="image" src="https://github.com/user-attachments/assets/b8950bb3-fdac-402e-90cb-3c196680672c" />
