### PR TITLE
unhide/display current search results on click (to fix #355)

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -528,6 +528,10 @@ export default class MaplibreGeocoder {
       noInitialSelection: true,
     });
 
+    this.container.addEventListener("click", () => {
+      this._typeahead.update(this._typeahead.data);
+    });
+
     this.setRenderFunction(this.options.render);
     this._typeahead.getItemValue = this.options.getItemValue;
 

--- a/test/integration/browser/browser.test.ts
+++ b/test/integration/browser/browser.test.ts
@@ -61,4 +61,22 @@ describe("Browser tests", () => {
 
     expect(results).toEqual(["Queen Street", "London"]);
   });
+
+  test("Show most recent search results after selecting a result and clicking on geocoder again", async () => {
+    await page.focus("div >>> .maplibregl-ctrl-geocoder--input");
+    await page.keyboard.type("england");
+    await page.keyboard.press("Enter");
+
+    await page.waitForSelector("div >>> .maplibregl-ctrl-geocoder--result", {
+      visible: true,
+    });
+
+    const searchResults = await page.$$('div >>> .maplibregl-ctrl-geocoder--result');
+    await searchResults[1].click();
+
+    await page.click("div >>> .maplibregl-ctrl-geocoder--input");
+
+    const searchResults2 = await page.$$('div >>> .maplibregl-ctrl-geocoder--result');
+    expect(searchResults2.length).toBe(2);
+  });
 });


### PR DESCRIPTION
<!-- Thanks for the PR! Feel free to add or remove items from the checklist. -->

 - [x] briefly describe the changes in this PR

After an item has been selected from the suggestions list, the list will be cleared (so unhiding the list is not enough as the UI contents are gone - however, data is still present in `geocoder._typeahead.data`). Hence, I added an event handler on "click" to trigger `geocoder._typeahead.update` to repopulate the suggestions list from `geocoder._typeahead.data`.
