### PR TITLE
Change input element type from text to search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features / Improvements 🚀
 
 - Add localization for French https://github.com/maplibre/maplibre-gl-geocoder/pull/412
+- Fix mobile Chrome search by changing input type https://github.com/maplibre/maplibre-gl-geocoder/pull/447
 
 ### Bug fixes 🐛
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -466,7 +466,7 @@ export default class MaplibreGeocoder {
     );
 
     this._inputEl = document.createElement("input");
-    this._inputEl.type = "text";
+    this._inputEl.type = "search";
     this._inputEl.className =
       "maplibregl-ctrl-geocoder--input";
 


### PR DESCRIPTION
Fixes #446  - on mobile Chrome the user can't submit the geocoder search if a second input field exists further down the page.


