### PR TITLE
Enhance GitHub Actions workflow for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,9 @@
 name: publish
 
+permissions:
+  id-token: write  # Required for trusted publishing
+  contents: write
+
 on:
   push:
     branches: [main]
@@ -63,8 +67,6 @@ jobs:
       - name: Publish NPM package
         run: |
           npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ORG_TOKEN }}
 
       - name: Tag commit and push
         id: tag_version

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/maplibre/maplibre-gl-geocoder.git"
+    "url": "https://github.com/maplibre/maplibre-gl-geocoder"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
Added permissions for id-token and contents in workflow.

This is the same change that was made to maplibre-style-spec due to changes in npm publishing policy
