### PR TITLE
Refactored search input styles to prevent duplication of the native clear pseudo-element.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 ### 🐞 Bug fixes
 - _...Add new stuff here..._
 
+## 1.9.5
+
+### 🐞 Bug fixes
+
+- Refactored search input styles to prevent duplication of the native clear pseudo-element.
 
 ## 1.9.4
 

--- a/lib/index.css
+++ b/lib/index.css
@@ -34,6 +34,14 @@
   overflow: hidden;
 }
 
+input[type="search"].maplibregl-ctrl-geocoder--input::-webkit-search-decoration,
+input[type="search"].maplibregl-ctrl-geocoder--input::-webkit-search-cancel-button,
+input[type="search"].maplibregl-ctrl-geocoder--input::-webkit-search-results-button,
+input[type="search"].maplibregl-ctrl-geocoder--input::-webkit-search-results-decoration {
+  display: none;
+  -webkit-appearance: none;
+}
+
 .maplibregl-ctrl-geocoder--input::-ms-clear {
   display: none; /* hide input clear button in IE */
 }


### PR DESCRIPTION
Linked to PR [#447](https://github.com/maplibre/maplibre-gl-geocoder/pull/447), this implementation maintains a consistent UI by suppressing the native search input pseudo-element, preventing duplicate clear icons.

 - [X] briefly describe the changes in this PR
 - [X] write tests for all new functionality (No need test - only css)
 - [x] update CHANGELOG.md with changes under `main` heading before merging
