### PR TITLE
chore(docs): Extend docs on usage outside a maplibre map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## main
 ### ✨ Features and improvements
-- _...Add new stuff here..._
+- Extend readme section on using the plugin without a maplibre map
 
 ### 🐞 Bug fixes
 - _...Add new stuff here..._

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-## MapLibre GL Geocoder
+# MapLibre GL Geocoder
 
 A geocoder control for [maplibre-gl-js](https://github.com/maplibre/maplibre-gl-js).
 
-### Usage
+## Usage
 
 A full working example can be found here, which uses Nominatim:
 https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/
@@ -35,23 +35,38 @@ map.addControl(geocoder);
 
 ```
 
-### Using without a Map
+### Usage without a Map
 
-It is possible to use the plugin without it being placed as a control on a maplibre-gl map.
+To use the plugin without placing it as a control on a maplibre-gl map, pass a HTML element or a CSS selector to the `addTo()`  function:
 
-### Deeper dive
+```html
+<div id="geocoder-container"></div>
+```
 
-#### API Documentation
+```js
+const GeoApi = {
+  forwardGeocode: (config) => { return { features: [] } },
+  reverseGeocode: (config) => { return { features: [] } }
+}
+const geocoder = new MaplibreGeocoder(GeoAPI, {});
+geocoder.addTo('#geocoder-container');
+```
+
+Note the target element must be present in the DOM when the plugin is initalised.
+
+## Deeper dive
+
+### API Documentation
 
 See [here](https://www.maplibre.org/maplibre-gl-geocoder/) for complete reference.
 
 Also check out the example in MapLibre docs:
 https://maplibre.org/maplibre-gl-js/docs/examples/geocode-with-nominatim/
 
-### Contributing
+## Contributing
 
 See [CONTRIBUTING.md](https://github.com/maplibre/maplibre-gl-geocoder/blob/main/CONTRIBUTING.md).
 
-### Licence
+## Licence
 
 ISC © [MapLibre](https://github.com/maplibre) © [Mapbox](https://github.com/mapbox)


### PR DESCRIPTION
- Extends readme section on using the plugin without a maplibre map following [this source comment](https://github.com/maplibre/maplibre-gl-geocoder/blob/main/lib/index.ts#L412-L430)
- Adjusts headline levels to start at `h1`

Closes #615 